### PR TITLE
fix: Handle case for empty complement cpu list

### DIFF
--- a/src/cpu/lists.go
+++ b/src/cpu/lists.go
@@ -26,7 +26,7 @@ func GenerateComplementCPUList(list string, maxcpus int) (string, error) {
 	}
 	if len(listprime) == 0 {
 		return "", fmt.Errorf(
-			"unable to generate complement: Cannot isolate all CPUs from IRQs",
+			"unable to complement cpu list '%s' for total of %d CPUs", list, maxcpus
 		)
 	}
 	return strings.Join(listprime, ","), nil


### PR DESCRIPTION
Check if final slice of strings is empty, then return an error.

 - Fixes #9