### PR TITLE
feat: stage util-linux for lscpu

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,8 @@ parts:
     plugin: go
     build-snaps:
       - go
+    stage-packages:
+      - util-linux
 
   config:
     plugin: dump


### PR DESCRIPTION
The execution of this line:

https://github.com/canonical/rt-conf/blob/8b22ec51293191dffd6cf485331122100fd4adfc/src/cpu/total.go#L12

Relies on the usage of `lscpu` command, which is part of `util-linux` deb package.