### PR TITLE
test: Add tests for 'all' cpulist flag

### DIFF
--- a/src/cpu/parse_test.go
+++ b/src/cpu/parse_test.go
@@ -15,6 +15,16 @@ func TestParseCPUSlistsHappy(t *testing.T) {
 	var tst = []test{
 		// single CPU
 		{
+			"all",
+			4,
+			CPUs{0: true, 1: true, 2: true, 3: true},
+		},
+		{
+			"all",
+			2,
+			CPUs{0: true, 1: true},
+		},
+		{
 			"4",
 			8,
 			CPUs{4: true},
@@ -85,6 +95,26 @@ func TestParseCPUSlistsUnhappy(t *testing.T) {
 	}
 
 	var tst = []test{
+		{
+			"al",
+			2,
+			"invalid CPU: al",
+		},
+		{
+			"alll",
+			2,
+			"invalid CPU: alll",
+		},
+		{
+			"0-all",
+			4,
+			"invalid end of range: all",
+		},
+		{
+			"all-n",
+			4,
+			"invalid start of range: all",
+		},
 		{
 			"4",
 			4,


### PR DESCRIPTION
Since the cpulist module already supports the `all` flag:

https://github.com/canonical/rt-conf/blob/d84b360a5fd686a300f64ce389c14a1f1ea65eac/src/cpu/parse.go#L31-L36

- Added on this PR: https://github.com/canonical/rt-conf/pull/7

- This adds tests to cover the correct behavior of the `all` flag.