### PR TITLE
Chore: drop proc-device-tree plug since hardware-observe is enough

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ After the installation it's necessary to connect the interfaces:
 - [hardware-observe](https://snapcraft.io/docs/hardware-observe-interface)
 - [home](https://snapcraft.io/docs/home-interface) - only if on Ubuntu Core
 - `etc-default-grub` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
-- `proc-device-tree-model` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
 - `proc-irq` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
 - `sys-kernel-irq` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
 
@@ -30,7 +29,6 @@ These can be done by running the following commands:
 sudo snap connect rt-conf:hardware-observe
 sudo snap connect rt-conf:home # Only in case of Ubuntu Core
 sudo snap connect rt-conf:etc-default-grub
-sudo snap connect rt-conf:proc-device-tree-model
 sudo snap connect rt-conf:proc-irq
 sudo snap connect rt-conf:sys-kernel-irq
 ```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,11 +28,6 @@ plugs:
     write:
       - /etc/default/grub
 
-  proc-device-tree-model:
-    interface: system-files
-    read:
-      - /proc/device-tree/model
-
   # NOTE: see https://github.com/canonical/rt-conf/issues/23
   sys-kernel-irq:
     interface: system-files
@@ -50,7 +45,6 @@ apps:
     plugs:
       - home
       - etc-default-grub
-      - proc-device-tree-model
       - hardware-observe
       - sys-kernel-irq
       - proc-irq


### PR DESCRIPTION
- Closes: https://github.com/canonical/rt-conf/issues/41


- `hardware-observe` interface provides read access to `/proc/device-tree`: https://github.com/canonical/snapd/blob/2.68.4/interfaces/builtin/hardware_observe.go#L91