### PR TITLE
Rename config flag and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Additional access is granted via [snap interfaces](https://snapcraft.io/docs/int
 After the installation it's necessary to connect the interfaces:
 
 - [hardware-observe](https://snapcraft.io/docs/hardware-observe-interface)
-- [home](https://snapcraft.io/docs/home-interface) - only if on Ubuntu Core
+- [home](https://snapcraft.io/docs/home-interface)
 - `etc-default-grub` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
 - `proc-device-tree-model` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
 - `proc-irq` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
@@ -28,7 +28,7 @@ These can be done by running the following commands:
 
 ```shell
 sudo snap connect rt-conf:hardware-observe
-sudo snap connect rt-conf:home # Only in case of Ubuntu Core
+sudo snap connect rt-conf:home
 sudo snap connect rt-conf:etc-default-grub
 sudo snap connect rt-conf:proc-device-tree-model
 sudo snap connect rt-conf:proc-irq
@@ -41,12 +41,18 @@ For example, copy it to the home directory:
 cp /snap/rt-conf/current/config.yaml ~/rt-conf.yaml
 ```
 
+### Default configuration file
+Upon installation the default rt-conf configuration file is added at: `/var/snap/rt-conf/common/config.yaml`.
+
 ## Usage
+
+Edit the [default configuration file](#default-configuration-file) or a copy of it.
+It you make a copy, make sure to place it in a directory accessible to the snap, such as the user home directory.
 
 Run rt-conf to apply the configurations:
 
 ```shell
-sudo rt-conf --file=/home/ubuntu/rt-conf.yaml
+sudo rt-conf --file=/var/snap/rt-conf/common/config.yaml
 ```
 
 Set `--help` for more details.
@@ -54,21 +60,28 @@ Set `--help` for more details.
 The rt-conf app can be set to as a oneshot service on system startup.
 This is useful for re-applying unpersisted IRQ tuning and power management settings on boot.
 
-To do so, set the configuration file path as snap configuration:
+By default, the service reads the [default configuration file](#default-configuration-file).
+
+To change the config file path, change the value of `config-file` snap configuration. Example:
 ```shell
 sudo snap set rt-conf config-file=/home/ubuntu/rt-conf.yaml
 ```
 
 Then, start and enable the service:
-```
+```shell
 sudo snap start --enable rt-conf
 ```
 
-### Debug logging
+Verify that it ran successfully by looking into the logs:
+```shell
+sudo snap logs -n 100 rt-conf
+```
 
-To enable debug logging, set either:
-- `DEBUG=1` environment variable or
-- `debug=1` snap configuration option.
+### Verbose logging
+
+To enable verbose logging, set:
+- `--verbose` flag on the CLI
+- `verbose=true` snap configuration option for the service
 
 
 ## Hacking

--- a/README.md
+++ b/README.md
@@ -38,20 +38,38 @@ sudo snap connect rt-conf:sys-kernel-irq
 Copy the example configuration file to a working directory accessible to the snap.
 For example, copy it to the home directory:
 ```shell
-cp /snap/rt-conf/current/config.yaml ~
+cp /snap/rt-conf/current/config.yaml ~/rt-conf.yaml
 ```
 
-## Use
+## Usage
 
-For usage instructions, run:
+Run rt-conf to apply the configurations:
 
 ```shell
-rt-conf --help
+sudo rt-conf --file=/home/ubuntu/rt-conf.yaml
 ```
+
+Set `--help` for more details.
+
+The rt-conf app can be set to as a oneshot service on system startup.
+This is useful for re-applying unpersisted IRQ tuning and power management settings on boot.
+
+To do so, set the configuration file path as snap configuration:
+```shell
+sudo snap set rt-conf config-file=/home/ubuntu/rt-conf.yaml
+```
+
+Then, start and enable the service:
+```
+sudo snap start --enable rt-conf
+```
+
+### Debug logging
 
 To enable debug logging, set either:
 - `DEBUG=1` environment variable or
 - `debug=1` snap configuration option.
+
 
 ## Hacking
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Upon installation the default rt-conf configuration file is added at: `/var/snap
 ## Usage
 
 Edit the [default configuration file](#default-configuration-file) or a copy of it.
-It you make a copy, make sure to place it in a directory accessible to the snap, such as the user home directory.
+In case of a copy, it must be placed it in a directory accessible to the snap, such as the user home directory.
 
 Run rt-conf to apply the configurations:
 ```shell

--- a/README.md
+++ b/README.md
@@ -50,19 +50,18 @@ Edit the [default configuration file](#default-configuration-file) or a copy of 
 It you make a copy, make sure to place it in a directory accessible to the snap, such as the user home directory.
 
 Run rt-conf to apply the configurations:
-
 ```shell
 sudo rt-conf --file=/var/snap/rt-conf/common/config.yaml
 ```
 
 Set `--help` for more details.
 
-The rt-conf app can be set to as a oneshot service on system startup.
-This is useful for re-applying unpersisted IRQ tuning and power management settings on boot.
+The rt-conf app can be set to run as a oneshot service on system startup.
+This is useful for re-applying non-persistent IRQ tuning and power management settings on boot.
 
 By default, the service reads the [default configuration file](#default-configuration-file).
 
-To change the config file path, change the value of `config-file` snap configuration. Example:
+To change the config file path, use the `config-file` snap configuration. Example:
 ```shell
 sudo snap set rt-conf config-file=/home/ubuntu/rt-conf.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ go run cmd/rt-conf/main.go
 > Also, you may want to use the local `config.yaml` file provided on the root of the repository:
 >
 > ```shell
-> go run cmd/rt-conf/main.go --config=./config.yaml -ui --grub-default=./test/grub
+> go run cmd/rt-conf/main.go --file=./config.yaml -ui --grub-file=./test/grub
 > ```
 
 Run tests:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ sudo snap connect rt-conf:proc-irq
 sudo snap connect rt-conf:sys-kernel-irq
 ```
 
+Copy the example configuration file to a working directory accessible to the snap.
+For example, copy it to the home directory:
+```shell
+cp /snap/rt-conf/current/config.yaml ~
+```
+
 ## Use
 
 For usage instructions, run:
@@ -43,7 +49,9 @@ For usage instructions, run:
 rt-conf --help
 ```
 
-To enable debug logging, set `DEBUG=1` environment variable.
+To enable debug logging, set either:
+- `DEBUG=1` environment variable or
+- `debug=1` snap configuration option.
 
 ## Hacking
 
@@ -66,6 +74,11 @@ go run cmd/rt-conf/main.go
 > ```shell
 > go run cmd/rt-conf/main.go --config=./config.yaml -ui --grub-default=./test/grub
 > ```
+
+Run tests:
+```shell
+go test ./...
+```
 
 ### Local Build
 

--- a/cmd/rt-conf/main.go
+++ b/cmd/rt-conf/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/canonical/rt-conf/src/debug"
 	"github.com/canonical/rt-conf/src/irq"
 	"github.com/canonical/rt-conf/src/kcmd"
 	"github.com/canonical/rt-conf/src/model"
@@ -18,10 +19,18 @@ func main() {
 	grubConfigPath := flag.String("grub-file",
 		"/etc/default/grub",
 		"Path to the grub configuration file, relevant only for GRUB bootloader")
+	verbose := flag.Bool("verbose",
+		false,
+		"Verbose mode, prints more information to the console")
 
 	flag.Parse()
 
-	log.Println(*configPath)
+	fmt.Println("Reading configuration file from", *configPath)
+
+	if *verbose {
+		fmt.Println("Verbose mode enabled")
+		debug.Enable()
+	}
 
 	if *configPath == "" {
 		flag.PrintDefaults()

--- a/cmd/rt-conf/main.go
+++ b/cmd/rt-conf/main.go
@@ -25,8 +25,6 @@ func main() {
 
 	flag.Parse()
 
-	fmt.Println("Reading configuration file from", *configPath)
-
 	if *verbose {
 		fmt.Println("Verbose mode enabled")
 		debug.Enable()
@@ -36,6 +34,8 @@ func main() {
 		flag.PrintDefaults()
 		log.Fatalf("Failed to load config file: path not set")
 	}
+
+	fmt.Println("Configuration file:", *configPath)
 
 	var conf model.InternalConfig
 	if d, err := model.LoadConfigFile(*configPath); err != nil {

--- a/config.yaml
+++ b/config.yaml
@@ -26,20 +26,20 @@ kernel_cmdline:
 
 # Runtime options for IRQ affinity
 irq_tuning:
-  - # The list of CPUs to which the IRQs are to be moved
-    # Format: range, e.g. 0-2
-    # cpus: "2-3"
-    # Arguments used to filter IRQs
-    # filter:
-      # actions: "iwlwifi"
-      # chip_name: "IR-PCI"
-      # name: "edge"
-      # type: "edge"
+  # - # CPUs to which the IRQs are to be moved
+  #   # Format: range, e.g. 0-2
+  #   cpus: "2-3"
+  #   # Arguments used to filter IRQs
+  #   filter:
+  #     actions: "iwlwifi"
+  #     chip_name: "IR-PCI"
+  #     name: "edge"
+  #     type: "edge"
 
 # Runtime options for CPU frequency scaling
 cpu_governance: 
-  # The list of CPUs to which the scaling_governor options are to be applied
-  # Format: CPU Lists
-  - cpus: "0-1"
-    scaling_governor: "performance"
+  # - # CPUs to which the scaling_governor options are to be applied
+  #   # Format: CPU Lists
+  #   cpus: "0-1"
+  #   scaling_governor: "performance"
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+# Placeholder for config validation

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,3 +1,10 @@
 #!/bin/bash -e
 
-# Placeholder for config validation
+verbose=$(snapctl get verbose)
+# if verbose is set, it should be either true or false
+if [[ -n "$verbose" && "$verbose" != "true" && "$verbose" != "false" ]]; then
+  echo "Invalid value for verbose: $verbose. It should be either true or false."
+  exit 1
+fi
+
+

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -15,5 +15,7 @@ default_config_path="$SNAP_COMMON"/config.yaml
 # Put the default configuration in place
 cp "$SNAP"/config.yaml "$default_config_path"
 
-# Set the default config file
-snapctl set config-file="$default_config_path"
+# Set the default config
+snapctl set config-file="$default_config_path" \
+            verbose=false
+

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -10,3 +10,10 @@ if ! snapctl is-connected etc-default-grub ||
   snapctl stop --disable "$SNAP_NAME.rt-confd"
 fi
 
+default_config_path="$SNAP_COMMON"/config.yaml
+
+# Put the default configuration in place
+cp "$SNAP"/config.yaml "$default_config_path"
+
+# Set the default config file
+snapctl set config-file="$default_config_path"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -10,5 +10,3 @@ if ! snapctl is-connected etc-default-grub ||
   snapctl stop --disable "$SNAP_NAME.rt-confd"
 fi
 
-# Put the default configuration in place
-cp "$SNAP"/config.yaml "$SNAP_COMMON"/config.yaml

--- a/snap/local/bin/load-snap-options
+++ b/snap/local/bin/load-snap-options
@@ -1,6 +1,0 @@
-#!/bin/bash -e
-
-export CONFIG_FILE=$(snapctl get config-file)
-export DEBUG=$(snapctl get debug)
-
-exec "$@"

--- a/snap/local/bin/load-snap-options
+++ b/snap/local/bin/load-snap-options
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+export CONFIG_FILE=$(snapctl get config-file)
+export DEBUG=$(snapctl get debug)
+
+exec "$@"

--- a/snap/local/bin/rt-confd
+++ b/snap/local/bin/rt-confd
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+config_file=$(snapctl get config-file)
+verbose=$(snapctl get verbose)
+
+verbose_flag=""
+if [[ -n "$verbose" ]]; then
+    verbose_flag="--verbose"
+fi
+
+exec "$SNAP"/bin/rt-conf --file "$config_file" $verbose_flag

--- a/snap/local/bin/rt-confd
+++ b/snap/local/bin/rt-confd
@@ -4,7 +4,7 @@ config_file=$(snapctl get config-file)
 verbose=$(snapctl get verbose)
 
 verbose_flag=""
-if [[ -n "$verbose" ]]; then
+if [[ "$verbose" == "true" ]]; then
     verbose_flag="--verbose"
 fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,13 +10,17 @@ grade: stable
 confinement: strict
 
 parts:
-  src:
+  local: 
+    source: snap/local
+    plugin: dump
+    
+  rt-conf:
     source: .
     plugin: go
     build-snaps:
       - go
 
-  config:
+  config-file:
     plugin: dump
     source: .
     stage:
@@ -57,9 +61,10 @@ apps:
       - snapd-control
       # - cpu-control # NOTE: this will replace `sys-kernel-irq` and `proc-irq`
     command: bin/rt-conf
-    environment:
-      COMMON_CONFIG_PATH: $SNAP_COMMON/config.yaml
 
   rt-confd:
     <<: *rt-conf
     daemon: oneshot
+    command-chain:
+      - bin/load-snap-options
+    command: bin/rt-conf --file $CONFIG_FILE

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,6 +27,10 @@ parts:
       - config.yaml
 
 plugs:
+  # For reading config file from user home directory as root
+  home:
+    read: all
+
   etc-default-grub:
     interface: system-files
     write:
@@ -65,6 +69,4 @@ apps:
   rt-confd:
     <<: *rt-conf
     daemon: oneshot
-    command-chain:
-      - bin/load-snap-options
-    command: bin/rt-conf --file $CONFIG_FILE
+    command: bin/rt-confd

--- a/src/debug/log.go
+++ b/src/debug/log.go
@@ -2,23 +2,22 @@ package debug
 
 import (
 	"log"
-	"os"
 )
 
-var d bool
+var debug bool
 
-func init() {
-	d = os.Getenv("DEBUG") == "1"
+func Enable() {
+	debug = true
 }
 
 func Printf(format string, v ...any) {
-	if d {
+	if debug {
 		log.Printf(format, v...)
 	}
 }
 
 func Println(v ...any) {
-	if d {
+	if debug {
 		log.Println(v...)
 	}
 }

--- a/src/kcmd/grub.go
+++ b/src/kcmd/grub.go
@@ -66,7 +66,7 @@ func UpdateGrub(cfg *model.InternalConfig) ([]string, error) {
 	}
 	grubDefault := &GrubDefaultTransformer{
 		FilePath: cfg.GrubDefault.File,
-		Pattern:  cfg.GrubDefault.Pattern,
+		Pattern:  model.PatternGrubDefault,
 	}
 
 	grubMap, err := ParseDefaultGrubFile(grubDefault.FilePath)

--- a/src/model/data.go
+++ b/src/model/data.go
@@ -5,8 +5,7 @@ import (
 )
 
 type InternalConfig struct {
-	CfgFile string
-	Data    Config
+	Data Config
 
 	GrubDefault Grub
 }

--- a/src/model/kcmdline_test.go
+++ b/src/model/kcmdline_test.go
@@ -66,7 +66,6 @@ func mainLogic(t *testing.T, c TestCase, i int) (string, error) {
 		conf.Data = *d
 	}
 
-	conf.CfgFile = tempConfigPath
 	conf.GrubDefault = model.Grub{
 		File:    tempGrubPath,
 		Pattern: model.PatternGrubDefault,


### PR DESCRIPTION
- Change config file flag from `config` to `file`.
- Remove config pattern setting from main.go
- Add snap option setting
- Comment out all example config
- Document service mode usage
- Change home plug to grant read access to all users' home directory. This is useful because rt-conf needs to always run as root.

```console
$ sudo snap install ./rt-conf_0.1_amd64.snap --dangerous 
rt-conf 0.1 installed

$ sudo snap get rt-conf 
Key          Value
config-file  /var/snap/rt-conf/common/config.yaml
verbose      false

$ sudo snap run rt-conf.rt-confd
Configuration file: /var/snap/rt-conf/common/config.yaml
2025/04/08 14:31:16 Failed to process kernel cmdline args: failed to parse grub file: open /etc/default/grub: permission denied

$ rt-conf 
  -file string
        Path to the configuration file
  -grub-file string
        Path to the grub configuration file, relevant only for GRUB bootloader (default "/etc/default/grub")
  -verbose
        Verbose mode, prints more information to the console
2025/04/08 14:31:03 Failed to load config file: path not set
```