### PR TITLE
Parse as int to correct number conversion

### DIFF
--- a/src/irq/irq.go
+++ b/src/irq/irq.go
@@ -75,7 +75,7 @@ func (r *realIRQReaderWriter) ReadIRQs() ([]IRQInfo, error) {
 	for _, entry := range dirEntries {
 		if entry.IsDir() {
 			nonActiveIRQ := true
-			number, err := strconv.ParseUint(entry.Name(), 10, 32)
+			number, err := strconv.ParseInt(entry.Name(), 10, 32)
 			if err != nil {
 				/* This may happen if the kernel IRQ structure
 				evolves sometime or somehow in the future */


### PR DESCRIPTION
Fixes https://github.com/canonical/rt-conf/security/code-scanning/3