### PR TITLE
refact: improve GrubConclusion function

### DIFF
--- a/src/kcmd/conclusion.go
+++ b/src/kcmd/conclusion.go
@@ -1,8 +1,16 @@
 package kcmd
 
-func GrubConclusion(grubFile string, diff []string) []string {
+func GrubConclusion(grubFile, old, new string) []string {
+	red := "\033[31m"
+	green := "\033[32m"
+	reset := "\033[0m"
+
 	s := []string{
 		"Detected bootloader: GRUB\n",
+		"Default kernel command line:\n",
+		red + "-  " + old + reset + "\n",
+		"New kernel command line:\n",
+		green + "+  " + new + reset + "\n",
 		"Updated default grub file: " + grubFile + "\n",
 		"\n",
 		"Please run:\n",
@@ -11,7 +19,6 @@ func GrubConclusion(grubFile string, diff []string) []string {
 		"\n",
 		"to apply the changes to your bootloader.\n",
 	}
-	s = append(s[:1], append(diff, s[1:]...)...)
 	return s
 }
 

--- a/src/kcmd/conclusion_test.go
+++ b/src/kcmd/conclusion_test.go
@@ -4,8 +4,18 @@ import "testing"
 
 func TestGrubConclusion(t *testing.T) {
 	grubFile := "/etc/default/grub"
+	red := "\033[31m"
+	green := "\033[32m"
+	reset := "\033[0m"
+	old := "quiet splash"
+	new := "quiet splash isolcpus=1-2"
+
 	expected := []string{
 		"Detected bootloader: GRUB\n",
+		"Default kernel command line:\n",
+		red + "-  " + old + reset + "\n",
+		"New kernel command line:\n",
+		green + "+  " + new + reset + "\n",
 		"Updated default grub file: " + grubFile + "\n",
 		"\n",
 		"Please run:\n",
@@ -15,15 +25,7 @@ func TestGrubConclusion(t *testing.T) {
 		"to apply the changes to your bootloader.\n",
 	}
 
-	expected = append(expected[:1],
-		append(printDiff("quiet splash",
-			"quiet splash isolcpus=1-2"),
-			expected[1:]...)...)
-
-	result := GrubConclusion(grubFile, printDiff(
-		"quiet splash",
-		"quiet splash isolcpus=1-2",
-	))
+	result := GrubConclusion(grubFile, old, new)
 
 	if len(result) != len(expected) {
 		t.Errorf("Expected %d lines, got %d", len(expected), len(result))

--- a/src/kcmd/grub.go
+++ b/src/kcmd/grub.go
@@ -17,19 +17,6 @@ func sortKcmdlineParams(cmdline string) string {
 	return strings.Join(params, " ")
 }
 
-func printDiff(old, new string) []string {
-	red := "\033[31m"
-	green := "\033[32m"
-	reset := "\033[0m"
-
-	return []string{
-		"Default kernel command line:\n",
-		red + "-  " + old + reset + "\n",
-		"New kernel command line:\n",
-		green + "+  " + new + reset + "\n",
-	}
-}
-
 // UpdateGrub reads GRUB_CMDLINE_LINUX_DEFAULT from the default GRUB configuration file,
 // merges it with the kernel command line parameters specified in the provided config,
 // and writes the resulting command line to a drop-in configuration file for GRUB.
@@ -69,7 +56,7 @@ func UpdateGrub(cfg *model.InternalConfig) ([]string, error) {
 	}
 
 	return GrubConclusion(cfg.GrubCfg.CustomGrubFilePath,
-		printDiff(cmdline, cfg.GrubCfg.Cmdline)), nil
+		cmdline, cfg.GrubCfg.Cmdline), nil
 }
 
 func parseGrubCMDLineLinuxDefault(path string) (string, error) {


### PR DESCRIPTION
- Added suggestions from https://github.com/canonical/rt-conf/pull/56#discussion_r2115682258

- This only does refactor, no changes in the final result of the logging
```
-----------------------------
Applying Kernel command lines
-----------------------------
Detected bootloader: GRUB
Default kernel command line:
-  quiet splash
New kernel command line:
+  nohz=on quiet splash
Updated default grub file: /etc/default/grub.d/60_rt-conf.cfg

Please run:

	sudo update-grub

to apply the changes to your bootloader.

-------------------
Applying IRQ tuning
-------------------

Rule #1 ( CPUs: 20-22, actions: nvme )
+ Skipped read-only (managed?) IRQs: 47-70
+ Assigned IRQs 45 to CPUs 20-22

-----------------------
Applying CPU Governance
-----------------------

Rule #1 ( CPUs: 22-23, scaling_governor: performance )
+ Set scaling governance of CPUs 22-23 to 22-23
```