### PR TITLE
feat: add Hint on error when config file isn't owned by root

### DIFF
--- a/src/model/config.go
+++ b/src/model/config.go
@@ -30,7 +30,10 @@ func LoadConfigFile(confPath string) (*Config, error) {
 	}
 
 	if !isOwnedByRoot(fileInfo) {
-		return nil, fmt.Errorf("file %s is not owned by root", confPath)
+		return nil, fmt.Errorf(
+			"file %s is not owned by root.\n\nHint: Change file ownership with:\nsudo chown root:root %s",
+			confPath, confPath,
+		)
 	}
 
 	content, err := ReadYAML(confPath)


### PR DESCRIPTION
- When trying to use a configuration file which isn't owned by root, an error is raised. 
- Since [`chown(1)`](https://man7.org/linux/man-pages/man1/chown.1p.html) is an essential tool (provided on coreutils) and the standard way of changing ownership of files, I don't see any good reason on why don't add this hint.

```console
$ sudo rt-conf --file ./config.yaml
Error: failed to load config file: file ./config.yaml is not owned by root.

Hint: Change file ownership with:
sudo chown root:root ./config.yaml
```