### PR TITLE
chore: display commit on version with format: v<version>+<commit>

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: rt-conf
 base: core24
-version: '0.1'
+version: nil
 summary: Configure and tune your real-time system
 description: |
   Tool destined to configure real-time parameters in a Linux system.
@@ -10,15 +10,17 @@ grade: stable
 confinement: strict
 
 parts:
-  local: 
+  local:
     source: snap/local
     plugin: dump
-    
+
   rt-conf:
     source: .
     plugin: go
     build-snaps:
       - go
+    override-build: |
+      craftctl set version=0.1+$(git describe --always --dirty)
 
   config-file:
     plugin: dump


### PR DESCRIPTION
One thing really annoying is always have to rebuild the snap once switching between branches to make sure that you're using the right built version.

Since we still in a [ZeroVer based versioning](https://0ver.org/) (for a good reason) I think this is good to help us to locate ourselves.