### PR TITLE
feat: Implement max/min frequency option on cpu_governance config

### DIFF
--- a/cmd/rt-conf/main_test.go
+++ b/cmd/rt-conf/main_test.go
@@ -127,7 +127,7 @@ cpu_governance:
 				t.Fatalf("expected error, got nil")
 			}
 			if !strings.Contains(err.Error(), test.err) {
-				t.Fatalf("expected error '%s', got: %v", test.err, err)
+				t.Fatalf("expected error '%s', got: '%v'", test.err, err)
 			}
 		})
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -42,4 +42,10 @@ cpu_governance:
   #   # Format: CPU Lists
   #   cpus: "0-1"
   #   scaling_governor: "performance"
+  #   # Minimum CPU frequency
+  #   # Format: frequency with unit, one of "GHz", "MHz", "kHz", "Hz"
+  #   min_freq: "1.2GHz"
+  #   # Maximum CPU frequency
+  #   # Format: same as min_freq
+  #   max_freq: "2.5GHz"
 

--- a/src/model/pwrmgmt.go
+++ b/src/model/pwrmgmt.go
@@ -56,10 +56,15 @@ func checkFreqLimits(min, max int) error {
 	if min == -1 && max == -1 {
 		return nil // No frequency limits set, nothing to check
 	}
-	if (min != -1 && max != -1) && max < min {
+	// The following checks only makes sense if both min and max are set
+	minAndMaxAreSet := min != -1 && max != -1
+	if max < min && minAndMaxAreSet {
 		return fmt.Errorf(
 			"max frequency (%d) cannot be less than min frequency (%d)",
 			max, min)
+	}
+	if min == max && minAndMaxAreSet {
+		return fmt.Errorf("min and max frequency cannot be the same: %d", min)
 	}
 	return nil
 }

--- a/src/model/pwrmgmt.go
+++ b/src/model/pwrmgmt.go
@@ -56,15 +56,10 @@ func checkFreqLimits(min, max int) error {
 	if min == -1 && max == -1 {
 		return nil // No frequency limits set, nothing to check
 	}
-	// The following checks only makes sense if both min and max are set
-	minAndMaxAreSet := min != -1 && max != -1
-	if max < min && minAndMaxAreSet {
+	if (min != -1 && max != -1) && max < min {
 		return fmt.Errorf(
 			"max frequency (%d) cannot be less than min frequency (%d)",
 			max, min)
-	}
-	if min == max && minAndMaxAreSet {
-		return fmt.Errorf("min and max frequency cannot be the same: %d", min)
 	}
 	return nil
 }

--- a/src/model/pwrmgmt.go
+++ b/src/model/pwrmgmt.go
@@ -2,6 +2,8 @@ package model
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/canonical/rt-conf/src/cpulists"
 )
@@ -23,15 +25,87 @@ var scalProfilesMap = map[string]ScalProfiles{
 type CpuGovernanceRule struct {
 	CPUs    string `yaml:"cpus"`
 	ScalGov string `yaml:"scaling_governor"`
+	MinFreq string `yaml:"min_freq"`
+	MaxFreq string `yaml:"max_freq"`
 }
 
 func (c CpuGovernanceRule) Validate() error {
-	if _, ok := scalProfilesMap[c.ScalGov]; !ok {
+	if _, err := cpulists.Parse(c.CPUs); err != nil {
+		return err
+	}
+	if _, ok := scalProfilesMap[c.ScalGov]; !ok && c.ScalGov != "" {
 		return fmt.Errorf("invalid cpu scaling governor: %v", c.ScalGov)
 	}
-	_, err := cpulists.Parse(c.CPUs)
-	if err != nil {
-		return fmt.Errorf("invalid cpus: %v", err)
+	min, errMin := ParseFreq(c.MinFreq)
+	if errMin != nil {
+		return fmt.Errorf("invalid min frequency: %v", errMin)
+	}
+	max, errMax := ParseFreq(c.MaxFreq)
+	if errMax != nil {
+		return fmt.Errorf("invalid max frequency: %v", errMax)
+	}
+
+	if err := checkFreqLimits(min, max); err != nil {
+		return fmt.Errorf("frequency limits check failed: %v", err)
+	}
+
+	return nil
+}
+
+func checkFreqLimits(min, max int) error {
+	if min == -1 && max == -1 {
+		return nil // No frequency limits set, nothing to check
+	}
+	// The following checks only makes sense if both min and max are set
+	minAndMaxAreSet := min != -1 && max != -1
+	if max < min && minAndMaxAreSet {
+		return fmt.Errorf(
+			"max frequency (%d) cannot be less than min frequency (%d)",
+			max, min)
+	}
+	if min == max && minAndMaxAreSet {
+		return fmt.Errorf("min and max frequency cannot be the same: %d", min)
 	}
 	return nil
+}
+
+func ParseFreq(freq string) (int, error) {
+	if freq == "" {
+		return -1, nil // No frequency limits set, nothing to parse
+	}
+
+	s := strings.ToLower(strings.TrimSpace(freq))
+	if !strings.HasSuffix(s, "hz") {
+		return -1, fmt.Errorf(
+			"invalid format: frequency must end with 'Hz': %s", s)
+	}
+
+	s = strings.TrimSuffix(s, "hz")
+
+	multiplier := 1.0
+	switch {
+	case strings.HasSuffix(s, "g"):
+		multiplier = 1_000_000.0
+		s = strings.TrimSuffix(s, "g")
+	case strings.HasSuffix(s, "m"):
+		multiplier = 1_000.0
+		s = strings.TrimSuffix(s, "m")
+	case strings.HasSuffix(s, "k"):
+		multiplier = 1.0
+		s = strings.TrimSuffix(s, "k")
+	default:
+		multiplier = 0.001 // Default to raw Hz if no metric prefix is provided
+	}
+
+	val, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return -1, fmt.Errorf("failed to parse frequency value: %v", err)
+	}
+
+	if val < 0 {
+		return -1, fmt.Errorf("frequency value cannot be negative: %s", s)
+	}
+
+	kHz := int(val * multiplier)
+	return kHz, nil
 }

--- a/src/model/pwrmgmt.go
+++ b/src/model/pwrmgmt.go
@@ -33,39 +33,38 @@ func (c CpuGovernanceRule) Validate() error {
 	if _, err := cpulists.Parse(c.CPUs); err != nil {
 		return err
 	}
+
 	if _, ok := scalProfilesMap[c.ScalGov]; !ok && c.ScalGov != "" {
 		return fmt.Errorf("invalid cpu scaling governor: %v", c.ScalGov)
 	}
-	min, errMin := ParseFreq(c.MinFreq)
-	if errMin != nil {
-		return fmt.Errorf("invalid min frequency: %v", errMin)
+
+	min, err := ParseFreq(c.MinFreq)
+	if err != nil {
+		return fmt.Errorf("invalid min frequency: %v", err)
 	}
-	max, errMax := ParseFreq(c.MaxFreq)
-	if errMax != nil {
-		return fmt.Errorf("invalid max frequency: %v", errMax)
+	max, err := ParseFreq(c.MaxFreq)
+	if err != nil {
+		return fmt.Errorf("invalid max frequency: %v", err)
 	}
 
-	if err := checkFreqLimits(min, max); err != nil {
-		return fmt.Errorf("frequency limits check failed: %v", err)
+	if err := validateFreqRange(min, max); err != nil {
+		return fmt.Errorf("invalid frequency range: %v", err)
 	}
 
 	return nil
 }
 
-func checkFreqLimits(min, max int) error {
+func validateFreqRange(min, max int) error {
 	if min == -1 && max == -1 {
-		return nil // No frequency limits set, nothing to check
+		return nil // No frequency bounds
 	}
-	// The following checks only makes sense if both min and max are set
-	minAndMaxAreSet := min != -1 && max != -1
-	if max < min && minAndMaxAreSet {
+
+	if (min != -1 && max != -1) && max < min {
 		return fmt.Errorf(
-			"max frequency (%d) cannot be less than min frequency (%d)",
+			"max frequency (%d) should not be less than min frequency (%d)",
 			max, min)
 	}
-	if min == max && minAndMaxAreSet {
-		return fmt.Errorf("min and max frequency cannot be the same: %d", min)
-	}
+
 	return nil
 }
 

--- a/src/model/pwrmgmt_test.go
+++ b/src/model/pwrmgmt_test.go
@@ -194,15 +194,6 @@ func TestCheckFreqFormat(t *testing.T) { //TODO: drop this test
 			},
 			wantErr: "cannot be less than min frequency",
 		},
-		{
-			name: "min and max frequency cannot be the same",
-			rule: CpuGovernanceRule{
-				CPUs:    "0",
-				MinFreq: "2.1GHz",
-				MaxFreq: "2.1GHz",
-			},
-			wantErr: "min and max frequency cannot be the same",
-		},
 	}
 
 	for _, tc := range tests {

--- a/src/model/pwrmgmt_test.go
+++ b/src/model/pwrmgmt_test.go
@@ -192,16 +192,7 @@ func TestCheckFreqFormat(t *testing.T) { //TODO: drop this test
 				MinFreq: "3.4GHz",
 				MaxFreq: "2.1GHz",
 			},
-			wantErr: "cannot be less than min frequency",
-		},
-		{
-			name: "min and max frequency cannot be the same",
-			rule: CpuGovernanceRule{
-				CPUs:    "0",
-				MinFreq: "2.1GHz",
-				MaxFreq: "2.1GHz",
-			},
-			wantErr: "min and max frequency cannot be the same",
+			wantErr: "should not be less than min frequency",
 		},
 	}
 

--- a/src/model/pwrmgmt_test.go
+++ b/src/model/pwrmgmt_test.go
@@ -1,6 +1,9 @@
 package model
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestPwrMgmtValidationHappy(t *testing.T) {
 	var happyCases = []CpuGovernanceRule{
@@ -61,9 +64,163 @@ func TestPwrMgmtValidationUnhappy(t *testing.T) {
 				t.Fatalf("Expected error on test #%v: %v", i, tc.sclgov)
 			}
 			if err.Error() != tc.err {
-				t.Fatalf("Expected error message: %s, got: %s", tc.err, err)
+				t.Fatalf("Expected error message: %q, got: %q", tc.err, err)
 			}
 
+		})
+	}
+}
+
+func TestCheckFreqFormat(t *testing.T) { //TODO: drop this test
+	tests := []struct {
+		name    string
+		rule    CpuGovernanceRule
+		wantErr string
+	}{
+		{
+			name: "valid GHz and MHz",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "1800mHz",
+				MaxFreq: "3.4GHz",
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid MHz and KHz",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "1800mHz",
+				MaxFreq: "2000000000000kHz",
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid raw Hz and KHz",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "1800000000Hz",
+				MaxFreq: "2000000000000kHz",
+			},
+			wantErr: "",
+		},
+		{
+			name: "invalid cpulist",
+			rule: CpuGovernanceRule{
+				CPUs:    "zz",
+				MinFreq: "1800mHz",
+				MaxFreq: "2000000000000kHz",
+			},
+			wantErr: "invalid CPU: zz",
+		},
+		{
+			name: "invalid unit only value",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "MHz",
+				MaxFreq: "GHz",
+			},
+			wantErr: "invalid min frequency:",
+		},
+		{
+			name: "invalid G and M suffix only",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "1.2M",
+				MaxFreq: "2.4G",
+			},
+			wantErr: "invalid min frequency:",
+		},
+		{
+			name: "invalid no unit suffix",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "1800000",
+				MaxFreq: "2400000",
+			},
+			wantErr: "invalid min frequency:",
+		},
+		{
+			name: "invalid float without unit",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "1.2",
+				MaxFreq: "2.5",
+			},
+			wantErr: "invalid min frequency:",
+		},
+		{
+			name: "valid lowercase hz",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "1.0mhz",
+				MaxFreq: "3.0gghz",
+			},
+			wantErr: "invalid max frequency:",
+		},
+		{
+			name: "invalid max freq string",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "1.2GHz",
+				MaxFreq: "threeGHz",
+			},
+			wantErr: "invalid max frequency:",
+		},
+		{
+			name: "invalid min freq string",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "oneGHz",
+				MaxFreq: "3.4GHz",
+			},
+			wantErr: "invalid min frequency:",
+		},
+		{
+			name: "both max and min invalid",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "badMin",
+				MaxFreq: "badMax",
+			},
+			wantErr: "invalid min frequency:",
+		},
+		{
+			name: "max freq less than min",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "3.4GHz",
+				MaxFreq: "2.1GHz",
+			},
+			wantErr: "cannot be less than min frequency",
+		},
+		{
+			name: "min and max frequency cannot be the same",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "2.1GHz",
+				MaxFreq: "2.1GHz",
+			},
+			wantErr: "min and max frequency cannot be the same",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.rule.Validate()
+			if tc.wantErr == "" && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error: %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("expected error: %q, got: %q",
+						tc.wantErr,
+						err.Error())
+				}
+			}
 		})
 	}
 }

--- a/src/model/pwrmgmt_test.go
+++ b/src/model/pwrmgmt_test.go
@@ -194,6 +194,15 @@ func TestCheckFreqFormat(t *testing.T) { //TODO: drop this test
 			},
 			wantErr: "cannot be less than min frequency",
 		},
+		{
+			name: "min and max frequency cannot be the same",
+			rule: CpuGovernanceRule{
+				CPUs:    "0",
+				MinFreq: "2.1GHz",
+				MaxFreq: "2.1GHz",
+			},
+			wantErr: "min and max frequency cannot be the same",
+		},
 	}
 
 	for _, tc := range tests {

--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -4,26 +4,52 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/canonical/rt-conf/src/cpulists"
 	"github.com/canonical/rt-conf/src/model"
 )
 
 type ReaderWriter struct {
-	Path string
+	ScalingGovernorPath string
+	MinFreqPath         string
+	MaxFreqPath         string
 }
 
-var scalingGovernorReaderWriter = ReaderWriter{
-	Path: "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_governor",
+var pwrmgmtReaderWriter = ReaderWriter{
+	ScalingGovernorPath: "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_governor",
+	MinFreqPath:         "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_min_freq",
+	MaxFreqPath:         "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_max_freq",
 }
 
 func (w ReaderWriter) WriteScalingGov(sclgov string, cpu int) error {
-	scalingGovFile := fmt.Sprintf(w.Path, cpu)
+	if sclgov == "" {
+		return nil // No scaling governor set, nothing to write
+	}
+	scalingGovFile := fmt.Sprintf(w.ScalingGovernorPath, cpu)
 
 	err := os.WriteFile(scalingGovFile, []byte(sclgov), 0644)
 	if err != nil {
 		return fmt.Errorf("error writing to %s: %v", scalingGovFile, err)
 	}
+	return nil
+}
+
+func (w ReaderWriter) WriteCPUFreq(freqMin, freqMax, cpu int) error {
+
+	minFreqSysfs := fmt.Sprintf(w.MinFreqPath, cpu)
+	if err := os.WriteFile(minFreqSysfs, []byte(strconv.Itoa(freqMin)),
+		0644); err != nil {
+		return fmt.Errorf("error writing to %s: %v", minFreqSysfs, err)
+	}
+
+	maxFreqSysfs := fmt.Sprintf(w.MaxFreqPath, cpu)
+	if err := os.WriteFile(maxFreqSysfs, []byte(strconv.Itoa(freqMax)),
+		0644); err != nil {
+		return fmt.Errorf("error writing to %s: %v", maxFreqSysfs, err)
+	}
+
 	return nil
 }
 
@@ -36,7 +62,7 @@ func ApplyPwrConfig(config *model.InternalConfig) error {
 		log.Println("No CPU governance rules found in config")
 		return nil
 	}
-	return scalingGovernorReaderWriter.applyPwrConfig(config.Data.CpuGovernance)
+	return pwrmgmtReaderWriter.applyPwrConfig(config.Data.CpuGovernance)
 }
 
 // Apply changes based on YAML config
@@ -47,8 +73,7 @@ func (wr ReaderWriter) applyPwrConfig(
 	// Range over all CPU governance rules
 	for i, sclgov := range rules {
 
-		log.Printf("\nRule #%d ( CPUs: %s, scaling_governor: %s )\n",
-			i+1, sclgov.CPUs, sclgov.ScalGov)
+		logRule(i, sclgov)
 		cpus, err := cpulists.Parse(sclgov.CPUs)
 		if err != nil {
 			return err
@@ -57,23 +82,73 @@ func (wr ReaderWriter) applyPwrConfig(
 		var setCpus []int
 
 		for cpu := range cpus {
-			err := wr.WriteScalingGov(sclgov.ScalGov, cpu)
-			if err != nil {
-				return err
+			if err := wr.applyRule(cpu, sclgov); err != nil {
+				return fmt.Errorf("failed to apply CPU governance rule #%d for CPU %d: %v",
+					i+1, cpu, err)
 			}
 			setCpus = append(setCpus, cpu)
 		}
-		logChanges(setCpus, sclgov.CPUs)
+		logChanges(setCpus, sclgov.MinFreq, sclgov.MaxFreq, sclgov.ScalGov)
 	}
 
 	return nil
 }
 
-func logChanges(cpus []int, scalingGov string) {
-	if len(cpus) == 0 {
-		log.Println("Rule does not match any CPUs.")
-		return
+func logRule(index int, sclgov model.CpuGovernanceRule) {
+	// Use a slice to build the log message dynamically
+	fields := []string{
+		fmt.Sprintf("CPUs: %s", sclgov.CPUs),
+		fmt.Sprintf("scaling_governor: %s", sclgov.ScalGov),
 	}
-	log.Printf("+ Set scaling governance of CPUs %s to %s",
-		cpulists.GenCPUlist(cpus), scalingGov)
+	if sclgov.MinFreq != "" {
+		fields = append(fields, fmt.Sprintf("min_freq: %s", sclgov.MinFreq))
+	}
+	if sclgov.MaxFreq != "" {
+		fields = append(fields, fmt.Sprintf("max_freq: %s", sclgov.MaxFreq))
+	}
+	log.Printf("\nRule #%d ( %s )\n", index+1, strings.Join(fields, ", "))
+}
+
+func logChanges(cpus []int, minFreq, maxFreq, scalingGov string) {
+	cpusName := "CPUs"
+	if len(cpus) == 1 {
+		cpusName = "CPU"
+	}
+	log.Printf("+ Set scaling governance of %s %s to %s\n",
+		cpusName, cpulists.GenCPUlist(cpus), scalingGov)
+
+	minFreqConnector := "└── "
+	if minFreq != "" {
+		if maxFreq != "" {
+			minFreqConnector = "├── "
+		}
+		log.Printf("%sSet min frequency of %s %s to %s\n",
+			minFreqConnector, cpusName, cpulists.GenCPUlist(cpus), minFreq)
+	}
+	if maxFreq != "" {
+		log.Printf("└── Set max frequency of %s %s to %s\n",
+			cpusName, cpulists.GenCPUlist(cpus), maxFreq)
+	}
+}
+
+func (wr ReaderWriter) applyRule(cpu int,
+	sclgov model.CpuGovernanceRule) error {
+	if err := wr.WriteScalingGov(sclgov.ScalGov, cpu); err != nil {
+		return err
+	}
+	minFreq, err := model.ParseFreq(sclgov.MinFreq)
+	if err != nil {
+		return err
+	}
+	maxFreq, err := model.ParseFreq(sclgov.MaxFreq)
+	if err != nil {
+		return err
+	}
+	if err := wr.WriteCPUFreq(
+		minFreq,
+		maxFreq,
+		cpu); err != nil {
+		return fmt.Errorf("failed to set CPU frequency for CPU %d: %v", cpu, err)
+	}
+	return nil
 }


### PR DESCRIPTION
* feat: add support for configuring min/max frequency on cpu_governance config of scaling governor

* feat: add max/min frequency on CPUGovernanceRule struct

* feat(model/pwrmgmt): Accept only formats with full units (GHz, MHz, KHz, Hz)

* feat: make scaling_governor field on config file optional

* feat: improve logging messages

* feat: make plural 'CPUs' on logs conditional
 
* feat(config.yaml): add description of format for min/max freq
