### PR TITLE
Fix CPU governance freq validation

### DIFF
--- a/src/model/pwrmgmt.go
+++ b/src/model/pwrmgmt.go
@@ -63,9 +63,7 @@ func checkFreqLimits(min, max int) error {
 			"max frequency (%d) cannot be less than min frequency (%d)",
 			max, min)
 	}
-	if min == max && minAndMaxAreSet {
-		return fmt.Errorf("min and max frequency cannot be the same: %d", min)
-	}
+
 	return nil
 }
 

--- a/src/model/pwrmgmt_test.go
+++ b/src/model/pwrmgmt_test.go
@@ -194,15 +194,6 @@ func TestCheckFreqFormat(t *testing.T) { //TODO: drop this test
 			},
 			wantErr: "cannot be less than min frequency",
 		},
-		{
-			name: "min and max frequency cannot be the same",
-			rule: CpuGovernanceRule{
-				CPUs:    "0",
-				MinFreq: "2.1GHz",
-				MaxFreq: "2.1GHz",
-			},
-			wantErr: "min and max frequency cannot be the same",
-		},
 	}
 
 	for _, tc := range tests {

--- a/src/model/pwrmgmt_test.go
+++ b/src/model/pwrmgmt_test.go
@@ -192,7 +192,7 @@ func TestCheckFreqFormat(t *testing.T) { //TODO: drop this test
 				MinFreq: "3.4GHz",
 				MaxFreq: "2.1GHz",
 			},
-			wantErr: "cannot be less than min frequency",
+			wantErr: "should not be less than min frequency",
 		},
 	}
 


### PR DESCRIPTION
- Remove rejection of zero-length range. As mentioned in https://github.com/canonical/rt-conf/pull/71#discussion_r2182394281, setting this is useful in real-time applications to improve the determinism and avoid overheating. Moreover, this is useful when benchmarking the system.

- Refactor conditional statements (see https://github.com/canonical/rt-conf/pull/71#discussion_r2182397442)

- Remove strange error variables (see https://github.com/canonical/rt-conf/pull/71#discussion_r2182379806)

The current unit tests are very fragile as mentioned in https://github.com/canonical/rt-conf/pull/71#discussion_r2176925047. The change here is to fix a broken test because of error message changes!