### PR TITLE
refact: remove explicit permission when writing to CPU governance and freq files

### DIFF
--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -23,13 +23,27 @@ var pwrmgmtReaderWriter = ReaderWriter{
 	MaxFreqPath:         "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_max_freq",
 }
 
+func writeOnly(path string, data string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
+	if err != nil {
+		return fmt.Errorf("error opening %s: %v", path, err)
+	}
+	defer f.Close()
+
+	f.Write([]byte(data))
+	if err != nil {
+		return fmt.Errorf("error writing to %s: %v", path, err)
+	}
+	return nil
+}
+
 func (w ReaderWriter) WriteScalingGov(sclgov string, cpu int) error {
 	if sclgov == "" {
 		return nil // No scaling governor set, nothing to write
 	}
 	scalingGovFile := fmt.Sprintf(w.ScalingGovernorPath, cpu)
 
-	err := os.WriteFile(scalingGovFile, []byte(sclgov), 0)
+	err := writeOnly(scalingGovFile, sclgov)
 	if err != nil {
 		return fmt.Errorf("error writing to %s: %v", scalingGovFile, err)
 	}
@@ -39,16 +53,16 @@ func (w ReaderWriter) WriteScalingGov(sclgov string, cpu int) error {
 func (w ReaderWriter) WriteCPUFreq(freqMin, freqMax, cpu int) error {
 	if freqMin != -1 {
 		minFreqSysfs := fmt.Sprintf(w.MinFreqPath, cpu)
-		if err := os.WriteFile(minFreqSysfs, []byte(strconv.Itoa(freqMin)),
-			0644); err != nil {
+		if err := writeOnly(minFreqSysfs,
+			strconv.Itoa(freqMin)); err != nil {
 			return fmt.Errorf("error writing to %s: %v", minFreqSysfs, err)
 		}
 	}
 
 	if freqMax != -1 {
 		maxFreqSysfs := fmt.Sprintf(w.MaxFreqPath, cpu)
-		if err := os.WriteFile(maxFreqSysfs, []byte(strconv.Itoa(freqMax)),
-			0644); err != nil {
+		if err := writeOnly(maxFreqSysfs,
+			strconv.Itoa(freqMax)); err != nil {
 			return fmt.Errorf("error writing to %s: %v", maxFreqSysfs, err)
 		}
 	}

--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -29,7 +29,7 @@ func (w ReaderWriter) WriteScalingGov(sclgov string, cpu int) error {
 	}
 	scalingGovFile := fmt.Sprintf(w.ScalingGovernorPath, cpu)
 
-	err := os.WriteFile(scalingGovFile, []byte(sclgov), 0644)
+	err := os.WriteFile(scalingGovFile, []byte(sclgov), 0)
 	if err != nil {
 		return fmt.Errorf("error writing to %s: %v", scalingGovFile, err)
 	}
@@ -37,16 +37,15 @@ func (w ReaderWriter) WriteScalingGov(sclgov string, cpu int) error {
 }
 
 func (w ReaderWriter) WriteCPUFreq(freqMin, freqMax, cpu int) error {
-
 	minFreqSysfs := fmt.Sprintf(w.MinFreqPath, cpu)
 	if err := os.WriteFile(minFreqSysfs, []byte(strconv.Itoa(freqMin)),
-		0644); err != nil {
+		0); err != nil {
 		return fmt.Errorf("error writing to %s: %v", minFreqSysfs, err)
 	}
 
 	maxFreqSysfs := fmt.Sprintf(w.MaxFreqPath, cpu)
 	if err := os.WriteFile(maxFreqSysfs, []byte(strconv.Itoa(freqMax)),
-		0644); err != nil {
+		0); err != nil {
 		return fmt.Errorf("error writing to %s: %v", maxFreqSysfs, err)
 	}
 

--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -30,7 +30,7 @@ func writeOnly(path string, data string) error {
 	}
 	defer f.Close()
 
-	f.Write([]byte(data))
+	_, err = f.Write([]byte(data))
 	if err != nil {
 		return fmt.Errorf("error writing to %s: %v", path, err)
 	}


### PR DESCRIPTION
Fix for TIOBE security warning:

'The "FileMode" argument is explicitly set to an insecure value making the file world-readable, world-writeable or world-executeable.

Level: 3
Category: Audit impact security
Synopsis: File permissions are set to an insecure value.
Ruleset: Go Security
Tool: Coverity 2024.12.1
'

Since the FileMode argument is only used if the file doesn't exists, we can safely set it to 0.

From Go os pkg documentation[1]:

> If the file does not exist, WriteFile creates it with permissions perm (before umask);
otherwise WriteFile truncates it before writing, without changing permissions.

[1]: https://pkg.go.dev/os#WriteFile