### PR TITLE
test: increase code coverage for applyRule function

### DIFF
--- a/src/pwr_mgmt/pwr_test.go
+++ b/src/pwr_mgmt/pwr_test.go
@@ -453,7 +453,9 @@ func TestApplyRuleUnhappy(t *testing.T) {
 
 			err := pwrmgmtReaderWriter.applyRule(0, tc.sclgov)
 			if err == nil {
-				t.Fatalf("expected error got nil")
+				t.Fatalf(
+					"expected error when processing %+v got nil", tc.sclgov,
+				)
 			}
 		})
 	}


### PR DESCRIPTION
The function `applyRule` on `pwrmgmt` module, lacks of test coverage for the failure cases, as shown in the go report:

```
git switch main
go test -cover -coverprofile cover.out ./...;
go tool cover -html cover.out -o cover.html;
```
<img width="884" height="427" alt="image" src="https://github.com/user-attachments/assets/bf3f34b9-1ae0-49f2-b1f2-dba1e8d3b4fb" />


This change increases the test coverage of `src/pwr_mgmt/pwr.go` from **86.5%** to **96.9%**.