### PR TITLE
feat: add remove hook and access to etc-default-grub for remove hook

### DIFF
--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+if snapctl is-connected etc-default-grubd; then
+  rm /etc/default/grub.d/60_rt-conf.cfg || true
+  exit 0
+fi
+
+echo "WARN: The etc-default-grubd plug isn't connected, please manually remove the config file on /etc/default/grub.d/60_rt-conf.cfg" >&2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,11 @@ plugs:
     read:
       - /etc/default/grub
 
+hooks:
+  remove:
+    plugs:
+      - etc-default-grub
+
 apps:
   rt-conf: &rt-conf
     plugs:


### PR DESCRIPTION
- Add remove hook to drop custom GRUB config file 60_rt-conf.cfg

- snapcraft.yaml: add hooks session with remove hook to access /etc/default/grub.d/60_rt-conf.cfg

- Closes: https://github.com/canonical/rt-conf/issues/75