### PR TITLE
feat: improve output formatting

### DIFF
--- a/src/irq/irq.go
+++ b/src/irq/irq.go
@@ -226,10 +226,15 @@ func matchesRegex(value, pattern string) bool {
 }
 
 func logChanges(changed, managed []int, cpus string) {
+	cpusName := "CPUs"
+	if len(cpus) == 1 {
+		cpusName = "CPU"
+	}
+
 	var msgs []string
 	if len(changed) > 0 {
-		msgs = append(msgs, fmt.Sprintf("Assigned IRQs %s to CPUs %s",
-			cpulists.GenCPUlist(changed), cpus))
+		msgs = append(msgs, fmt.Sprintf("Assigned IRQs %s to %s %s",
+			cpulists.GenCPUlist(changed), cpusName, cpus))
 	}
 
 	if len(managed) > 0 {

--- a/src/irq/irq.go
+++ b/src/irq/irq.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/rt-conf/src/cpulists"
 	"github.com/canonical/rt-conf/src/debug"
 	"github.com/canonical/rt-conf/src/model"
+	"github.com/canonical/rt-conf/src/utils"
 )
 
 // NOTE: to be able to remap IRQs:
@@ -135,10 +136,7 @@ func (r *realIRQReaderWriter) ReadIRQs() ([]IRQInfo, error) {
 }
 
 func ApplyIRQConfig(config *model.InternalConfig) error {
-	log.Println("\n-------------------")
-	log.Println("Applying IRQ tuning")
-	log.Println("-------------------")
-
+	utils.PrintTitle("IRQ Tuning")
 	if len(config.Data.Interrupts) == 0 {
 		// If no IRQ tuning is specified, skip the process
 		log.Println("No IRQ tuning rules found in config")
@@ -164,7 +162,7 @@ func applyIRQConfig(
 
 	// Range over IRQ tuning array
 	for label, irqTuning := range config.Data.Interrupts {
-		log.Printf("\nRule: %s\n", label)
+		log.Printf("Rule: %s\n", label)
 
 		matchingIRQs, err := filterIRQs(irqs, irqTuning.Filter)
 		if err != nil {
@@ -228,11 +226,16 @@ func matchesRegex(value, pattern string) bool {
 }
 
 func logChanges(changed, managed []int, cpus string) {
-	if len(managed) > 0 {
-		log.Printf("+ Skipped read-only (managed?) IRQs: %s",
-			cpulists.GenCPUlist(managed))
-	}
+	var msgs []string
 	if len(changed) > 0 {
-		log.Printf("+ Assigned IRQs %s to CPUs %s", cpulists.GenCPUlist(changed), cpus)
+		msgs = append(msgs, fmt.Sprintf("Assigned IRQs %s to CPUs %s",
+			cpulists.GenCPUlist(changed), cpus))
 	}
+
+	if len(managed) > 0 {
+		msgs = append(msgs, fmt.Sprintf("Ignored managed IRQs: %s",
+			cpulists.GenCPUlist(managed)))
+
+	}
+	utils.LogTreeStyle(msgs)
 }

--- a/src/irq/irq.go
+++ b/src/irq/irq.go
@@ -196,8 +196,7 @@ func applyIRQConfig(
 		if err != nil {
 			return err
 		}
-		logChanges(setIRQs, managedIRQs, defineIfUsePluralForCPUs(cpus),
-			irqTuning.CPUs)
+		logChanges(setIRQs, managedIRQs, cpus, irqTuning.CPUs)
 	}
 	return nil
 }
@@ -231,11 +230,16 @@ func matchesRegex(value, pattern string) bool {
 	return err == nil && match
 }
 
-func logChanges(changed, managed []int, cpusName, cpus string) {
+func logChanges(changed, managed []int, cpuList cpulists.CPUs, cpus string) {
+	pluralSuffix := "s"
+	if len(cpuList) == 1 {
+		pluralSuffix = ""
+	}
+
 	var msgs []string
 	if len(changed) > 0 {
-		msgs = append(msgs, fmt.Sprintf("Assigned IRQs %s to %s %s",
-			cpulists.GenCPUlist(changed), cpusName, cpus))
+		msgs = append(msgs, fmt.Sprintf("Assigned IRQs %s to CPU%s %s",
+			cpulists.GenCPUlist(changed), pluralSuffix, cpus))
 	}
 
 	if len(managed) > 0 {
@@ -244,16 +248,4 @@ func logChanges(changed, managed []int, cpusName, cpus string) {
 
 	}
 	utils.LogTreeStyle(msgs)
-}
-
-func defineIfUsePluralForCPUs(cpuList cpulists.CPUs) string {
-	var cpusSlice []int
-	for cpu := range cpuList {
-		cpusSlice = append(cpusSlice, cpu)
-	}
-	cpus := cpulists.GenCPUlist(cpusSlice)
-	if len(cpus) == 1 {
-		return "CPU"
-	}
-	return "CPUs"
 }

--- a/src/irq/irq.go
+++ b/src/irq/irq.go
@@ -191,7 +191,13 @@ func applyIRQConfig(
 				setIRQs = append(setIRQs, irqNum)
 			}
 		}
-		logChanges(setIRQs, managedIRQs, irqTuning.CPUs)
+
+		cpus, err := cpulists.Parse(irqTuning.CPUs)
+		if err != nil {
+			return err
+		}
+		logChanges(setIRQs, managedIRQs, defineIfUsePluralForCPUs(cpus),
+			irqTuning.CPUs)
 	}
 	return nil
 }
@@ -225,12 +231,7 @@ func matchesRegex(value, pattern string) bool {
 	return err == nil && match
 }
 
-func logChanges(changed, managed []int, cpus string) {
-	cpusName := "CPUs"
-	if len(cpus) == 1 {
-		cpusName = "CPU"
-	}
-
+func logChanges(changed, managed []int, cpusName, cpus string) {
 	var msgs []string
 	if len(changed) > 0 {
 		msgs = append(msgs, fmt.Sprintf("Assigned IRQs %s to %s %s",
@@ -243,4 +244,16 @@ func logChanges(changed, managed []int, cpus string) {
 
 	}
 	utils.LogTreeStyle(msgs)
+}
+
+func defineIfUsePluralForCPUs(cpuList cpulists.CPUs) string {
+	var cpusSlice []int
+	for cpu := range cpuList {
+		cpusSlice = append(cpusSlice, cpu)
+	}
+	cpus := cpulists.GenCPUlist(cpusSlice)
+	if len(cpus) == 1 {
+		return "CPU"
+	}
+	return "CPUs"
 }

--- a/src/irq/irq_test.go
+++ b/src/irq/irq_test.go
@@ -67,6 +67,22 @@ irq_tuning:
 				},
 			},
 		},
+		{
+			Yaml: `
+irq_tuning:
+  "foo":
+    cpus: 0,1
+    filter:
+      action: nvme01
+`,
+			Handler: &mockIRQReaderWriter{
+				IRQs: map[uint]IRQInfo{
+					0: {
+						Actions: "nvme01",
+					},
+				},
+			},
+		},
 	}
 
 	for i, c := range happyCases {

--- a/src/kcmd/args.go
+++ b/src/kcmd/args.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/canonical/rt-conf/src/model"
 	"github.com/canonical/rt-conf/src/system"
+	"github.com/canonical/rt-conf/src/utils"
 )
 
 var kcmdSys = map[system.SystemType]func(*model.InternalConfig) ([]string, error){
@@ -15,10 +16,7 @@ var kcmdSys = map[system.SystemType]func(*model.InternalConfig) ([]string, error
 }
 
 func ProcessKcmdArgs(c *model.InternalConfig) ([]string, error) {
-	log.Println("\n-----------------------------")
-	log.Println("Applying Kernel command lines")
-	log.Println("-----------------------------")
-
+	utils.PrintTitle("Kernel Command Line Parameters")
 	if c.Data.KernelCmdline == (model.KernelCmdline{}) {
 		// No kernel command line options to process
 		log.Println("No kernel command line options to process")

--- a/src/kcmd/conclusion.go
+++ b/src/kcmd/conclusion.go
@@ -18,6 +18,7 @@ func GrubConclusion(grubFile, old, new string) []string {
 		"\tsudo update-grub\n",
 		"\n",
 		"to apply the changes to your bootloader.\n",
+		"\n",
 	}
 	return s
 }
@@ -41,6 +42,7 @@ func UbuntuCoreConclusion() []string {
 		"\n",
 		"Sucessfully applied the changes.\n",
 		"Please reboot your system to apply the changes.\n",
+		"\n",
 	}
 	return s
 }

--- a/src/kcmd/conclusion_test.go
+++ b/src/kcmd/conclusion_test.go
@@ -23,6 +23,7 @@ func TestGrubConclusion(t *testing.T) {
 		"\tsudo update-grub\n",
 		"\n",
 		"to apply the changes to your bootloader.\n",
+		"\n",
 	}
 
 	result := GrubConclusion(grubFile, old, new)
@@ -68,6 +69,7 @@ func TestUbuntuCoreConclusion(t *testing.T) {
 		"\n",
 		"Sucessfully applied the changes.\n",
 		"Please reboot your system to apply the changes.\n",
+		"\n",
 	}
 	result := UbuntuCoreConclusion()
 

--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/canonical/rt-conf/src/cpulists"
 	"github.com/canonical/rt-conf/src/model"
+	"github.com/canonical/rt-conf/src/utils"
 )
 
 type ReaderWriter struct {
@@ -70,10 +71,7 @@ func (w ReaderWriter) WriteCPUFreq(freqMin, freqMax, cpu int) error {
 }
 
 func ApplyPwrConfig(config *model.InternalConfig) error {
-	log.Println("\n-----------------------")
-	log.Println("Applying CPU Governance")
-	log.Println("-----------------------")
-
+	utils.PrintTitle("CPU Governance")
 	if len(config.Data.CpuGovernance) == 0 {
 		log.Println("No CPU governance rules found in config")
 		return nil
@@ -89,7 +87,7 @@ func (wr ReaderWriter) applyPwrConfig(
 	// Range over all CPU governance rules
 	for label, sclgov := range rules {
 
-		log.Printf("\nRule: %s \n", label)
+		log.Printf("Rule: %s \n", label)
 		cpus, err := cpulists.Parse(sclgov.CPUs)
 		if err != nil {
 			return err
@@ -115,21 +113,26 @@ func logChanges(cpus []int, minFreq, maxFreq, scalingGov string) {
 	if len(cpus) == 1 {
 		cpusName = "CPU"
 	}
-	log.Printf("+ Set scaling governance of %s %s to %s\n",
-		cpusName, cpulists.GenCPUlist(cpus), scalingGov)
+	cpuList := cpulists.GenCPUlist(cpus)
 
-	minFreqConnector := "└── "
+	var msg []string
+	if scalingGov != "" {
+		msg = append(msg,
+			fmt.Sprintf("Set scaling governance of %s %s to %s", cpusName,
+				cpuList, scalingGov))
+	}
 	if minFreq != "" {
-		if maxFreq != "" {
-			minFreqConnector = "├── "
-		}
-		log.Printf("%sSet min frequency of %s %s to %s\n",
-			minFreqConnector, cpusName, cpulists.GenCPUlist(cpus), minFreq)
+		msg = append(msg,
+			fmt.Sprintf("Set min frequency of %s %s to %s", cpusName, cpuList,
+				minFreq))
 	}
 	if maxFreq != "" {
-		log.Printf("└── Set max frequency of %s %s to %s\n",
-			cpusName, cpulists.GenCPUlist(cpus), maxFreq)
+		msg = append(msg,
+			fmt.Sprintf("Set max frequency of %s %s to %s", cpusName, cpuList,
+				maxFreq))
 	}
+
+	utils.LogTreeStyle(msg)
 }
 
 func (wr ReaderWriter) applyRule(cpu int,

--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -109,27 +109,27 @@ func (wr ReaderWriter) applyPwrConfig(
 }
 
 func logChanges(cpus []int, minFreq, maxFreq, scalingGov string) {
-	cpusName := "CPUs"
+	pluralSuffix := "s"
 	if len(cpus) == 1 {
-		cpusName = "CPU"
+		pluralSuffix = ""
 	}
 	cpuList := cpulists.GenCPUlist(cpus)
 
 	var msg []string
 	if scalingGov != "" {
 		msg = append(msg,
-			fmt.Sprintf("Set scaling governance of %s %s to %s", cpusName,
+			fmt.Sprintf("Set scaling governance of CPU%s %s to %s", pluralSuffix,
 				cpuList, scalingGov))
 	}
 	if minFreq != "" {
 		msg = append(msg,
-			fmt.Sprintf("Set min frequency of %s %s to %s", cpusName, cpuList,
-				minFreq))
+			fmt.Sprintf("Set min frequency of CPU%s %s to %s", pluralSuffix,
+				cpuList, minFreq))
 	}
 	if maxFreq != "" {
 		msg = append(msg,
-			fmt.Sprintf("Set max frequency of %s %s to %s", cpusName, cpuList,
-				maxFreq))
+			fmt.Sprintf("Set max frequency of CPU%s %s to %s", pluralSuffix,
+				cpuList, maxFreq))
 	}
 
 	utils.LogTreeStyle(msg)

--- a/src/utils/print.go
+++ b/src/utils/print.go
@@ -8,10 +8,10 @@ import (
 
 const (
 	// Bold text
-	initColor = "\033[1m"
+	initFmt = "\033[1m"
 
 	// Reset formatting
-	endColor = "\033[0m"
+	endFmt = "\033[0m"
 )
 
 // Print title in bold inside box with an orange background color
@@ -26,12 +26,12 @@ func PrintTitle(title string) {
 
 func printBoldBgText(format string, args ...any) {
 	text := fmt.Sprintf(format, args...)
-	log.Printf("%s%s%s", initColor, text, endColor)
+	log.Printf("%s%s%s", initFmt, text, endFmt)
 }
 
 func printlnBoldBgText(format string, args ...any) {
 	text := fmt.Sprintf(format, args...)
-	log.Printf("%s%s%s\n", initColor, text, endColor)
+	log.Printf("%s%s%s\n", initFmt, text, endFmt)
 }
 
 func LogTreeStyle(entries []string) {

--- a/src/utils/print.go
+++ b/src/utils/print.go
@@ -3,40 +3,34 @@ package utils
 import (
 	"fmt"
 	"log"
+	"strings"
+)
+
+const (
+	// Bold text with Ubuntu orange background
+	initColor = "\033[1;48;2;233;84;32m"
+
+	// Reset color
+	endColor = "\033[0m"
 )
 
 // Print title in bold inside box with an orange background color
 func PrintTitle(title string) {
-
-	printBoldBgText("┌")
-	for i := 0; i <= len(title)+1; i++ {
-		printBoldBgText("─")
-	}
-	printlnBoldBgText("┐")
-
+	tittleLine := strings.Repeat("─", len(title)+2)
+	printlnBoldBgText("┌" + tittleLine + "┐")
 	printlnBoldBgText("│ %s │", title)
-
-	printBoldBgText("└")
-	for i := 0; i <= len(title)+1; i++ {
-		printBoldBgText("─")
-	}
-	printlnBoldBgText("┘")
-
+	printlnBoldBgText("└" + tittleLine + "┘")
 	log.Println()
 }
 
 func printBoldBgText(format string, args ...any) {
-	// Ubuntu orange color
-	r, g, b := 0xE9, 0x54, 0x20
 	text := fmt.Sprintf(format, args...)
-	fmt.Printf("\033[1;48;2;%d;%d;%dm%s\033[0m", r, g, b, text)
+	log.Printf("%s%s%s", initColor, text, endColor)
 }
 
 func printlnBoldBgText(format string, args ...any) {
-	// Ubuntu orange color
-	r, g, b := 0xE9, 0x54, 0x20
 	text := fmt.Sprintf(format, args...)
-	fmt.Printf("\033[1;48;2;%d;%d;%dm%s\033[0m\n", r, g, b, text)
+	log.Printf("%s%s%s\n", initColor, text, endColor)
 }
 
 func LogTreeStyle(entries []string) {

--- a/src/utils/print.go
+++ b/src/utils/print.go
@@ -8,10 +8,10 @@ import (
 
 const (
 	// Bold text
-	initFmt = "\033[1m"
+	startBold = "\033[1m"
 
 	// Reset formatting
-	endFmt = "\033[0m"
+	endBold = "\033[0m"
 )
 
 // Print title in bold inside box
@@ -26,12 +26,12 @@ func PrintTitle(title string) {
 
 func printBoldBgText(format string, args ...any) {
 	text := fmt.Sprintf(format, args...)
-	log.Printf("%s%s%s", initFmt, text, endFmt)
+	log.Printf("%s%s%s", startBold, text, endBold)
 }
 
 func printlnBoldBgText(format string, args ...any) {
 	text := fmt.Sprintf(format, args...)
-	log.Printf("%s%s%s\n", initFmt, text, endFmt)
+	log.Printf("%s%s%s\n", startBold, text, endBold)
 }
 
 func LogTreeStyle(entries []string) {

--- a/src/utils/print.go
+++ b/src/utils/print.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+)
+
+// Print title in bold inside box with an orange background color
+func PrintTitle(title string) {
+
+	// fmt.Printf("┌")
+	printBoldBgText("┌")
+	for i := 0; i <= len(title)+1; i++ {
+		// fmt.Printf("─")
+		printBoldBgText("─")
+	}
+	// fmt.Println("┐")
+	printlnBoldBgText("┐")
+
+	// fmt.Printf("│ %s │\n", title)
+	printlnBoldBgText("│ %s │", title)
+
+	// fmt.Printf("└")
+	printBoldBgText("└")
+	for i := 0; i <= len(title)+1; i++ {
+		// fmt.Printf("─")
+		printBoldBgText("─")
+	}
+	// fmt.Println("┘")
+	printlnBoldBgText("┘")
+
+	log.Println()
+}
+
+func printBoldBgText(format string, args ...any) {
+	// Ubuntu orange color
+	r, g, b := 0xE9, 0x54, 0x20
+	text := fmt.Sprintf(format, args...)
+	fmt.Printf("\033[1;48;2;%d;%d;%dm%s\033[0m", r, g, b, text)
+}
+
+func printlnBoldBgText(format string, args ...any) {
+	// Ubuntu orange color
+	r, g, b := 0xE9, 0x54, 0x20
+	text := fmt.Sprintf(format, args...)
+	fmt.Printf("\033[1;48;2;%d;%d;%dm%s\033[0m\n", r, g, b, text)
+}
+
+func LogTreeStyle(entries []string) {
+	for i, entry := range entries {
+		prefix := "├── "
+		if i == len(entries)-1 {
+			prefix = "└── "
+		}
+		log.Printf("%s%s\n", prefix, entry)
+	}
+	log.Println()
+}

--- a/src/utils/print.go
+++ b/src/utils/print.go
@@ -10,7 +10,7 @@ const (
 	// Bold text
 	initColor = "\033[1m"
 
-	// Reset color
+	// Reset formatting
 	endColor = "\033[0m"
 )
 

--- a/src/utils/print.go
+++ b/src/utils/print.go
@@ -16,10 +16,11 @@ const (
 
 // Print title in bold inside box with an orange background color
 func PrintTitle(title string) {
+	log.Println()
 	tittleLine := strings.Repeat("─", len(title)+2)
-	printlnBoldBgText("┌" + tittleLine + "┐")
-	printlnBoldBgText("│ %s │", title)
-	printlnBoldBgText("└" + tittleLine + "┘")
+	printlnBoldBgText("  ┌" + tittleLine + "┐")
+	printlnBoldBgText("  │ %s │", title)
+	printBoldBgText("  └" + tittleLine + "┘")
 	log.Println()
 }
 

--- a/src/utils/print.go
+++ b/src/utils/print.go
@@ -14,7 +14,7 @@ const (
 	endFmt = "\033[0m"
 )
 
-// Print title in bold inside box with an orange background color
+// Print title in bold inside box
 func PrintTitle(title string) {
 	log.Println()
 	tittleLine := strings.Repeat("─", len(title)+2)

--- a/src/utils/print.go
+++ b/src/utils/print.go
@@ -8,25 +8,18 @@ import (
 // Print title in bold inside box with an orange background color
 func PrintTitle(title string) {
 
-	// fmt.Printf("┌")
 	printBoldBgText("┌")
 	for i := 0; i <= len(title)+1; i++ {
-		// fmt.Printf("─")
 		printBoldBgText("─")
 	}
-	// fmt.Println("┐")
 	printlnBoldBgText("┐")
 
-	// fmt.Printf("│ %s │\n", title)
 	printlnBoldBgText("│ %s │", title)
 
-	// fmt.Printf("└")
 	printBoldBgText("└")
 	for i := 0; i <= len(title)+1; i++ {
-		// fmt.Printf("─")
 		printBoldBgText("─")
 	}
-	// fmt.Println("┘")
 	printlnBoldBgText("┘")
 
 	log.Println()

--- a/src/utils/print.go
+++ b/src/utils/print.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	// Bold text with Ubuntu orange background
-	initColor = "\033[1;48;2;233;84;32m"
+	// Bold text
+	initColor = "\033[1m"
 
 	// Reset color
 	endColor = "\033[0m"

--- a/src/utils/print_test.go
+++ b/src/utils/print_test.go
@@ -8,20 +8,9 @@ import (
 	"testing"
 )
 
-// Helper: capture stdout
-func captureStdout(f func()) string {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	f()
-
-	w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	return buf.String()
+func TestMain(m *testing.M) {
+	log.SetFlags(0)
+	os.Exit(m.Run())
 }
 
 // Helper: capture log output
@@ -35,34 +24,34 @@ func captureLogOutput(f func()) string {
 }
 
 func TestPrintBoldBgText(t *testing.T) {
-	output := captureStdout(func() {
+	output := captureLogOutput(func() {
 		printBoldBgText("Hello %s", "world")
 	})
-	expectedSubstring := "\033[1;48;2;233;84;32mHello world\033[0m"
+	expectedSubstring := initColor + "Hello world" + endColor
 	if !strings.Contains(output, expectedSubstring) {
 		t.Errorf("expected escape sequence with colored text, got: %q", output)
 	}
 }
 
 func TestPrintlnBoldBgText(t *testing.T) {
-	output := captureStdout(func() {
+	output := captureLogOutput(func() {
 		printlnBoldBgText("Test %d", 123)
 	})
-	expectedSubstring := "\033[1;48;2;233;84;32mTest 123\033[0m"
+	expectedSubstring := initColor + "Test 123" + endColor
 	if !strings.Contains(output, expectedSubstring) {
-		t.Errorf("expected colored output with newline, got: %q", output)
+		t.Errorf("expected: %q, got: %q", expectedSubstring, output)
 	}
 }
 
 func TestPrintTitle(t *testing.T) {
-	output := captureStdout(func() {
+	output := captureLogOutput(func() {
 		PrintTitle("Header")
 	})
 	// We expect box-drawing characters and colored title line
 	if !strings.Contains(output, "│ Header │") {
 		t.Errorf("title box missing expected content, got: %q", output)
 	}
-	if !strings.Contains(output, "\033[1;48;2;233;84;32m") {
+	if !strings.Contains(output, initColor) {
 		t.Errorf("expected background color escape sequence, got: %q", output)
 	}
 }

--- a/src/utils/print_test.go
+++ b/src/utils/print_test.go
@@ -53,7 +53,7 @@ func TestPrintTitle(t *testing.T) {
 	})
 
 	// We expect box-drawing characters and colored title line
-	assertContains(t, output, "| Header |")
+	assertContains(t, output, "│ Header │")
 	assertContains(t, output, initColor)
 }
 

--- a/src/utils/print_test.go
+++ b/src/utils/print_test.go
@@ -13,7 +13,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// Helper: capture log output
 func captureLogOutput(f func()) string {
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
@@ -52,7 +51,6 @@ func TestPrintTitle(t *testing.T) {
 		PrintTitle("Header")
 	})
 
-	// We expect box-drawing characters and colored title line
 	assertContains(t, output, "│ Header │")
 	assertContains(t, output, initColor)
 }

--- a/src/utils/print_test.go
+++ b/src/utils/print_test.go
@@ -23,14 +23,19 @@ func captureLogOutput(f func()) string {
 	return buf.String()
 }
 
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected to find %q in output: %q", needle, haystack)
+	}
+}
+
 func TestPrintBoldBgText(t *testing.T) {
 	output := captureLogOutput(func() {
 		printBoldBgText("Hello %s", "world")
 	})
 	expectedSubstring := initColor + "Hello world" + endColor
-	if !strings.Contains(output, expectedSubstring) {
-		t.Errorf("expected escape sequence with colored text, got: %q", output)
-	}
+	assertContains(t, output, expectedSubstring)
 }
 
 func TestPrintlnBoldBgText(t *testing.T) {
@@ -38,22 +43,18 @@ func TestPrintlnBoldBgText(t *testing.T) {
 		printlnBoldBgText("Test %d", 123)
 	})
 	expectedSubstring := initColor + "Test 123" + endColor
-	if !strings.Contains(output, expectedSubstring) {
-		t.Errorf("expected: %q, got: %q", expectedSubstring, output)
-	}
+	assertContains(t, output, "\n")
+	assertContains(t, output, expectedSubstring)
 }
 
 func TestPrintTitle(t *testing.T) {
 	output := captureLogOutput(func() {
 		PrintTitle("Header")
 	})
+
 	// We expect box-drawing characters and colored title line
-	if !strings.Contains(output, "│ Header │") {
-		t.Errorf("title box missing expected content, got: %q", output)
-	}
-	if !strings.Contains(output, initColor) {
-		t.Errorf("expected background color escape sequence, got: %q", output)
-	}
+	assertContains(t, output, "| Header |")
+	assertContains(t, output, initColor)
 }
 
 func TestLogTreeStyle(t *testing.T) {
@@ -67,8 +68,6 @@ func TestLogTreeStyle(t *testing.T) {
 		"└── three",
 	}
 	for _, line := range expected {
-		if !strings.Contains(output, line) {
-			t.Errorf("missing expected tree log entry: %q", line)
-		}
+		assertContains(t, output, line)
 	}
 }

--- a/src/utils/print_test.go
+++ b/src/utils/print_test.go
@@ -33,7 +33,7 @@ func TestPrintBoldBgText(t *testing.T) {
 	output := captureLogOutput(func() {
 		printBoldBgText("Hello %s", "world")
 	})
-	expectedSubstring := initColor + "Hello world" + endColor
+	expectedSubstring := "\033[1mHello world\033[0m"
 	assertContains(t, output, expectedSubstring)
 }
 
@@ -41,7 +41,7 @@ func TestPrintlnBoldBgText(t *testing.T) {
 	output := captureLogOutput(func() {
 		printlnBoldBgText("Test %d", 123)
 	})
-	expectedSubstring := initColor + "Test 123" + endColor
+	expectedSubstring := "\033[1mTest 123\033[0m"
 	assertContains(t, output, "\n")
 	assertContains(t, output, expectedSubstring)
 }

--- a/src/utils/print_test.go
+++ b/src/utils/print_test.go
@@ -52,7 +52,7 @@ func TestPrintTitle(t *testing.T) {
 	})
 
 	assertContains(t, output, "│ Header │")
-	assertContains(t, output, initColor)
+	assertContains(t, output, initFmt)
 }
 
 func TestLogTreeStyle(t *testing.T) {

--- a/src/utils/print_test.go
+++ b/src/utils/print_test.go
@@ -1,0 +1,85 @@
+package utils
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Helper: capture stdout
+func captureStdout(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	return buf.String()
+}
+
+// Helper: capture log output
+func captureLogOutput(f func()) string {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	f()
+	return buf.String()
+}
+
+func TestPrintBoldBgText(t *testing.T) {
+	output := captureStdout(func() {
+		printBoldBgText("Hello %s", "world")
+	})
+	expectedSubstring := "\033[1;48;2;233;84;32mHello world\033[0m"
+	if !strings.Contains(output, expectedSubstring) {
+		t.Errorf("expected escape sequence with colored text, got: %q", output)
+	}
+}
+
+func TestPrintlnBoldBgText(t *testing.T) {
+	output := captureStdout(func() {
+		printlnBoldBgText("Test %d", 123)
+	})
+	expectedSubstring := "\033[1;48;2;233;84;32mTest 123\033[0m"
+	if !strings.Contains(output, expectedSubstring) {
+		t.Errorf("expected colored output with newline, got: %q", output)
+	}
+}
+
+func TestPrintTitle(t *testing.T) {
+	output := captureStdout(func() {
+		PrintTitle("Header")
+	})
+	// We expect box-drawing characters and colored title line
+	if !strings.Contains(output, "│ Header │") {
+		t.Errorf("title box missing expected content, got: %q", output)
+	}
+	if !strings.Contains(output, "\033[1;48;2;233;84;32m") {
+		t.Errorf("expected background color escape sequence, got: %q", output)
+	}
+}
+
+func TestLogTreeStyle(t *testing.T) {
+	output := captureLogOutput(func() {
+		LogTreeStyle([]string{"one", "two", "three"})
+	})
+
+	expected := []string{
+		"├── one",
+		"├── two",
+		"└── three",
+	}
+	for _, line := range expected {
+		if !strings.Contains(output, line) {
+			t.Errorf("missing expected tree log entry: %q", line)
+		}
+	}
+}

--- a/src/utils/print_test.go
+++ b/src/utils/print_test.go
@@ -52,7 +52,7 @@ func TestPrintTitle(t *testing.T) {
 	})
 
 	assertContains(t, output, "│ Header │")
-	assertContains(t, output, initFmt)
+	assertContains(t, output, startBold)
 }
 
 func TestLogTreeStyle(t *testing.T) {


### PR DESCRIPTION
- utils: add utils package with logging functions
  - PrintTitle(): Add function to print title in bold inside a orange backgrounded square
  - LogTreeStyle(): Add function to given log entries, automatically put the right Tree style connector in front of the message
  - Add unit tests

- irq/irq.go: Refact logChanges() to make it scalable by using LogTreeStyle() from utils package

- pwr_mgmt/pwr.go: Refact logChanges() to make it scalable by using LogTreeStyle from utils package

- Closes: https://github.com/canonical/rt-conf/issues/85