### PR TITLE
Override config with snap options

### DIFF
--- a/cmd/rt-conf/main_test.go
+++ b/cmd/rt-conf/main_test.go
@@ -22,9 +22,9 @@ func TestRunHappy(t *testing.T) {
 			name: "Valid empty config",
 			args: []string{"rt-conf", "-file", configPath},
 			yaml: `
-kernel_cmdline:
-cpu_governance:
-irq_tuning:
+kernel-cmdline:
+cpu-governance:
+irq-tuning:
 `,
 		},
 	}
@@ -87,7 +87,7 @@ func TestRunUnhappy(t *testing.T) {
 			args: []string{"rt-conf", "-file", configPath},
 			err:  "failed to process kernel cmdline args",
 			yaml: `
-kernel_cmdline:
+kernel-cmdline:
     nohz: "on"
 `,
 		},
@@ -96,7 +96,7 @@ kernel_cmdline:
 			args: []string{"rt-conf", "-file", configPath},
 			err:  "failed to process interrupts",
 			yaml: `
-irq_tuning:
+irq-tuning:
   "foo":
     cpus: "0"
     filter:
@@ -108,10 +108,10 @@ irq_tuning:
 			args: []string{"rt-conf", "-file", configPath},
 			err:  "failed to process power management config",
 			yaml: `
-cpu_governance:
+cpu-governance:
   "bar":
     cpus: "0"
-    scaling_governor: "performance"
+    scaling-governor: "performance"
 `,
 		},
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@
 # https://docs.kernel.org/admin-guide/kernel-parameters.html#cpu-lists
 
 # Kernel command line parameters
-kernel_cmdline:
+kernel-cmdline:
   # Isolate CPUs from general execution
   # Format: CPU Lists
   # isolcpus: "2-3"
@@ -25,7 +25,7 @@ kernel_cmdline:
   # irqaffinity: "0-1"
 
 # Runtime options for IRQ affinity
-irq_tuning:
+irq-tuning:
   # # label for the IRQ tuning rule
   # my wireless interface:
   #   # CPUs to which the IRQs are to be moved
@@ -34,22 +34,22 @@ irq_tuning:
   #   # Arguments used to filter IRQs
   #   filter:
   #     actions: "iwlwifi"
-  #     chip_name: "IR-PCI"
+  #     chip-name: "IR-PCI"
   #     name: "edge"
   #     type: "edge"
 
 # Runtime options for CPU frequency scaling
-cpu_governance: 
+cpu-governance: 
   # # label for the CPU governance rule
   # kernel cores:
   #   # CPUs to which the scaling_governor options are to be applied
   #   # Format: CPU Lists
   #   cpus: "0-1"
-  #   scaling_governor: "performance"
+  #   scaling-governor: "performance"
   #   # Minimum CPU frequency
   #   # Format: frequency with unit, one of "GHz", "MHz", "kHz", "Hz"
-  #   min_freq: "1.2GHz"
+  #   min-freq: "1.2GHz"
   #   # Maximum CPU frequency
   #   # Format: same as min_freq
-  #   max_freq: "2.5GHz"
+  #   max-freq: "2.5GHz"
 

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.22.2
 
 require gopkg.in/yaml.v3 v3.0.1
 
-require github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722084158-0310595e9e52
+require github.com/canonical/go-snapctl v1.0.0-beta.3

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/canonical/rt-conf
 go 1.22.2
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722084158-0310595e9e52

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,5 @@
-github.com/canonical/go-snapctl v1.0.0-beta.2 h1:3M+9+uAg8vu5hIGQN/yOOcG6Esud7/eQgtZbD7DNjco=
-github.com/canonical/go-snapctl v1.0.0-beta.2/go.mod h1:c2Kkyh24L/nYD7YSLzoA6n/mI3/86IQekwXvBHL3G+Q=
-github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722081214-f29c4ec18c72 h1:kyA1ZM+CcCuOzuurHJ6wNXBhPhiMNEnVQmBlMnnRVpg=
-github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722081214-f29c4ec18c72/go.mod h1:c2Kkyh24L/nYD7YSLzoA6n/mI3/86IQekwXvBHL3G+Q=
-github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722082917-7e307c35615b h1:4NgUUWr17XD1+WyjhKnmEZw5Q5bbKlmxyXPFj7Zty+M=
-github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722082917-7e307c35615b/go.mod h1:c2Kkyh24L/nYD7YSLzoA6n/mI3/86IQekwXvBHL3G+Q=
-github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722084158-0310595e9e52 h1:p3Sp4bY1C5CDubvnOuEfwpDjQH55dyhWs6jNdIuAgNc=
-github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722084158-0310595e9e52/go.mod h1:c2Kkyh24L/nYD7YSLzoA6n/mI3/86IQekwXvBHL3G+Q=
+github.com/canonical/go-snapctl v1.0.0-beta.3 h1:lVfhh+7aRndPABZIVfDV19tdsxaSNKFWi3tkQ71XjEY=
+github.com/canonical/go-snapctl v1.0.0-beta.3/go.mod h1:c2Kkyh24L/nYD7YSLzoA6n/mI3/86IQekwXvBHL3G+Q=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,17 @@
+github.com/canonical/go-snapctl v1.0.0-beta.2 h1:3M+9+uAg8vu5hIGQN/yOOcG6Esud7/eQgtZbD7DNjco=
+github.com/canonical/go-snapctl v1.0.0-beta.2/go.mod h1:c2Kkyh24L/nYD7YSLzoA6n/mI3/86IQekwXvBHL3G+Q=
+github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722081214-f29c4ec18c72 h1:kyA1ZM+CcCuOzuurHJ6wNXBhPhiMNEnVQmBlMnnRVpg=
+github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722081214-f29c4ec18c72/go.mod h1:c2Kkyh24L/nYD7YSLzoA6n/mI3/86IQekwXvBHL3G+Q=
+github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722082917-7e307c35615b h1:4NgUUWr17XD1+WyjhKnmEZw5Q5bbKlmxyXPFj7Zty+M=
+github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722082917-7e307c35615b/go.mod h1:c2Kkyh24L/nYD7YSLzoA6n/mI3/86IQekwXvBHL3G+Q=
+github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722084158-0310595e9e52 h1:p3Sp4bY1C5CDubvnOuEfwpDjQH55dyhWs6jNdIuAgNc=
+github.com/canonical/go-snapctl v1.0.0-beta.2.0.20250722084158-0310595e9e52/go.mod h1:c2Kkyh24L/nYD7YSLzoA6n/mI3/86IQekwXvBHL3G+Q=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/src/irq/irq_test.go
+++ b/src/irq/irq_test.go
@@ -53,7 +53,7 @@ func TestHappyIRQtuning(t *testing.T) {
 	var happyCases = []IRQTestCase{
 		{
 			Yaml: `
-irq_tuning:
+irq-tuning:
   "foo":
     cpus: 0
     filter:
@@ -85,7 +85,7 @@ func TestUnhappyIRQtuning(t *testing.T) {
 		{
 			// Invalid number
 			Yaml: `
-irq_tuning:
+irq-tuning:
 - cpus: 0
   filter:
     number: a
@@ -95,7 +95,7 @@ irq_tuning:
 		{
 			// Invalid RegEx
 			Yaml: `
-irq_tuning:
+irq-tuning:
 - cpus: 0
   filter:
     number: 0
@@ -131,10 +131,8 @@ func mainLogicIRQ(t *testing.T, cfg IRQTestCase, i int) (string, error) {
 		os.Remove(tempConfigPath)
 	})
 	var conf model.InternalConfig
-	if d, err := model.LoadConfigFile(tempConfigPath); err != nil {
+	if err := conf.Data.LoadFromFile(tempConfigPath); err != nil {
 		return "", fmt.Errorf("failed to load config file: %v", err)
-	} else {
-		conf.Data = *d
 	}
 
 	err := applyIRQConfig(&conf, cfg.Handler)
@@ -257,7 +255,7 @@ func TestReadIRQsSingleActiveIRQ(t *testing.T) {
 			Number: 10,
 			Files: map[string]string{
 				"actions":   "handle_irq",
-				"chip_name": "testchip",
+				"chip-name": "testchip",
 				"name":      "eth0",
 				"type":      "level",
 				"wakeup":    "enabled",

--- a/src/model/config.go
+++ b/src/model/config.go
@@ -57,7 +57,11 @@ func (c *Config) LoadFromFile(confPath string) error {
 // When a value is set, the whole object gets overridden.
 func (c *Config) LoadSnapOptions() error {
 
-	value, err := snapctl.Get("irq-tuning", "cpu-governance").Document().Run()
+	value, err := snapctl.Get(
+		"kernel-cmdline",
+		"irq-tuning",
+		"cpu-governance",
+	).Document().Run()
 	if err != nil {
 		return fmt.Errorf("failed to get snap option: %v", err)
 	}
@@ -69,6 +73,11 @@ func (c *Config) LoadSnapOptions() error {
 	err = yaml.Unmarshal([]byte(value), &confOptions)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal snap options: %v", err)
+	}
+
+	// reject kernel command line arguments
+	if confOptions.KernelCmdline != (KernelCmdline{}) {
+		return fmt.Errorf("kernel-cmdline snap option is not supported, use the config file instead")
 	}
 
 	// override full objects

--- a/src/model/config.go
+++ b/src/model/config.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"syscall"
 	"testing"
+
+	"github.com/canonical/go-snapctl"
+	"gopkg.in/yaml.v3"
 )
 
 var expectedPermission os.FileMode = 0o644
@@ -17,26 +20,27 @@ var isOwnedByRoot = func(fi os.FileInfo) bool {
 	return uid == 0 // Check if the file is owned by root
 }
 
-func LoadConfigFile(confPath string) (*Config, error) {
+func (c *Config) LoadFromFile(confPath string) error {
 	fileInfo, err := os.Stat(confPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find file: %v", err)
+		return fmt.Errorf("failed to find file: %v", err)
 	}
 
 	if fileInfo.Mode() != expectedPermission {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"file %s has invalid permissions: %v, expected permissions %v",
 			confPath, fileInfo.Mode(), expectedPermission)
 	}
 
 	if !isOwnedByRoot(fileInfo) {
-		return nil, fmt.Errorf("file %s is not owned by root", confPath)
+		return fmt.Errorf("file %s is not owned by root", confPath)
 	}
 
-	content, err := ReadYAML(confPath)
+	cfg, err := ReadYAML(confPath)
 	if err != nil {
-		return nil, err
+		return err
 	}
+	*c = *cfg
 
 	/*
 		TODO: Needs to implement proper validation of the parameters
@@ -46,5 +50,39 @@ func LoadConfigFile(confPath string) (*Config, error) {
 			- key=value
 			- flag
 	*/
-	return content, nil
+	return nil
+}
+
+// LoadSnapOptions reads IRQ and CPU governance objects from snap options
+// When a value is set, the whole object gets overridden.
+func (c *Config) LoadSnapOptions() error {
+
+	value, err := snapctl.Get("irq-tuning", "cpu-governance").Document().Run()
+	if err != nil {
+		return fmt.Errorf("failed to get snap option: %v", err)
+	}
+
+	var confOptions Config
+
+	// Unmarshal json using YAML unmarshaler
+	// This works because YAML is a superset of JSON
+	err = yaml.Unmarshal([]byte(value), &confOptions)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal snap options: %v", err)
+	}
+
+	// override full objects
+	if len(confOptions.Interrupts) > 0 {
+		c.Interrupts = confOptions.Interrupts
+	}
+	if len(confOptions.CpuGovernance) > 0 {
+		c.CpuGovernance = confOptions.CpuGovernance
+	}
+
+	err = c.Validate()
+	if err != nil {
+		return fmt.Errorf("invalid configurations via snap options: %v", err)
+	}
+
+	return nil
 }

--- a/src/model/config_test.go
+++ b/src/model/config_test.go
@@ -46,7 +46,7 @@ func TestLoadConfigFile(t *testing.T) {
 		},
 		{
 			name:        "FileInvalidPermissions",
-			yaml:        "kernel_cmdline:",
+			yaml:        "kernel-cmdline:",
 			perm:        0755,
 			cfg:         nil,
 			err:         fmt.Errorf("has invalid permissions"),
@@ -54,7 +54,7 @@ func TestLoadConfigFile(t *testing.T) {
 		},
 		{
 			name:        "FileNotOwnedByRoot",
-			yaml:        `kernel_cmdline:`,
+			yaml:        `kernel-cmdline:`,
 			perm:        0644,
 			cfg:         nil,
 			err:         fmt.Errorf("not owned by root"),
@@ -62,7 +62,7 @@ func TestLoadConfigFile(t *testing.T) {
 		},
 		{
 			name:        "FailedToUnmarshalYAML",
-			yaml:        `kernel_cmdline: {`,
+			yaml:        `kernel-cmdline: {`,
 			perm:        0644,
 			cfg:         nil,
 			err:         fmt.Errorf("failed to unmarshal data"),
@@ -71,7 +71,7 @@ func TestLoadConfigFile(t *testing.T) {
 		{
 			name: "FileValid",
 			yaml: `
-kernel_cmdline:
+kernel-cmdline:
     nohz: "on"
     isolcpus: "1"
     kthread_cpus: "0"
@@ -105,7 +105,8 @@ kernel_cmdline:
 				}
 			}
 
-			cfg, err := LoadConfigFile(cfgFilePath)
+			var cfg Config
+			err := cfg.LoadFromFile(cfgFilePath)
 
 			// Unhappy cases
 			if tc.err != nil {
@@ -122,11 +123,8 @@ kernel_cmdline:
 			if err != nil {
 				t.Fatalf("expected no error, got '%v'", err)
 			}
-			if cfg == nil {
-				t.Fatalf("expected non-nil config, got nil")
-			}
-			if !reflect.DeepEqual(cfg, tc.cfg) {
-				t.Fatalf("expected config %v, got %v", tc.cfg, cfg)
+			if !reflect.DeepEqual(cfg, *tc.cfg) {
+				t.Fatalf("expected config %+v, got %+v", *tc.cfg, cfg)
 			}
 		})
 	}

--- a/src/model/data.go
+++ b/src/model/data.go
@@ -14,8 +14,8 @@ type PwrMgmt map[string]CpuGovernanceRule
 type Interrupts map[string]IRQTuning
 
 type Config struct {
-	Interrupts    Interrupts    `yaml:"irq-tuning"`
 	KernelCmdline KernelCmdline `yaml:"kernel-cmdline"`
+	Interrupts    Interrupts    `yaml:"irq-tuning"`
 	CpuGovernance PwrMgmt       `yaml:"cpu-governance"`
 }
 

--- a/src/model/data.go
+++ b/src/model/data.go
@@ -14,9 +14,9 @@ type PwrMgmt map[string]CpuGovernanceRule
 type Interrupts map[string]IRQTuning
 
 type Config struct {
-	Interrupts    Interrupts    `yaml:"irq_tuning"`
-	KernelCmdline KernelCmdline `yaml:"kernel_cmdline"`
-	CpuGovernance PwrMgmt       `yaml:"cpu_governance"`
+	Interrupts    Interrupts    `yaml:"irq-tuning"`
+	KernelCmdline KernelCmdline `yaml:"kernel-cmdline"`
+	CpuGovernance PwrMgmt       `yaml:"cpu-governance"`
 }
 
 func (c Config) Validate() error {

--- a/src/model/file_test.go
+++ b/src/model/file_test.go
@@ -40,7 +40,7 @@ func TestReadYAML(t *testing.T) {
 		{
 			name: "ValidationFails",
 			yaml: `
-kernel_cmdline:
+kernel-cmdline:
   nohz: "invalid_value"
 `,
 			cfg: nil,
@@ -49,7 +49,7 @@ kernel_cmdline:
 		{
 			name: "Success",
 			yaml: `
-kernel_cmdline:
+kernel-cmdline:
   nohz: "on"
 `,
 			cfg: &Config{

--- a/src/model/irq.go
+++ b/src/model/irq.go
@@ -38,7 +38,7 @@ func (c IRQTuning) Validate() error {
 
 type IRQFilter struct {
 	Actions  string `yaml:"actions" validation:"regex"`
-	ChipName string `yaml:"chip_name" validation:"regex"`
+	ChipName string `yaml:"chip-name" validation:"regex"`
 	Name     string `yaml:"name" validation:"regex"`
 	Type     string `yaml:"type" validation:"regex"`
 }

--- a/src/model/irq_test.go
+++ b/src/model/irq_test.go
@@ -18,7 +18,7 @@ func TestIRQTuningValidate(t *testing.T) {
 				CPUs: "0,1",
 				Filter: IRQFilter{
 					Actions:  `action`,
-					ChipName: `chip_name`,
+					ChipName: `chip-name`,
 					Name:     `name`,
 					Type:     `type`,
 				},
@@ -57,7 +57,7 @@ func TestIRQTuningValidate(t *testing.T) {
 				CPUs: "0,1",
 				Filter: IRQFilter{
 					Actions:  `(?!abc)def`, // Negative lookahead
-					ChipName: `chip_name`,
+					ChipName: `chip-name`,
 					Name:     `name`,
 					Type:     `type`,
 				},

--- a/src/model/kcmdline_test.go
+++ b/src/model/kcmdline_test.go
@@ -59,10 +59,8 @@ func mainLogic(t *testing.T, c TestCase, i int) (string, error) {
 	t.Logf("tempCustomCfgPath: %s\n", tempCustomCfgPath)
 
 	var conf model.InternalConfig
-	if d, err := model.LoadConfigFile(tempConfigPath); err != nil {
+	if err := conf.Data.LoadFromFile(tempConfigPath); err != nil {
 		return "", fmt.Errorf("failed to load config file: %v", err)
-	} else {
-		conf.Data = *d
 	}
 
 	conf.GrubCfg = model.Grub{
@@ -93,7 +91,7 @@ func TestHappyYamlKcmd(t *testing.T) {
 	var happyCases = []TestCase{
 		{
 			Yaml: `
-kernel_cmdline:
+kernel-cmdline:
   isolcpus: "0-n"
   nohz: "on"
   nohz_full: "0-n"
@@ -113,7 +111,7 @@ kernel_cmdline:
 		},
 		{
 			Yaml: `
-kernel_cmdline:
+kernel-cmdline:
   isolcpus: "0"
   nohz: "off"
   nohz_full: "0-n"
@@ -156,7 +154,7 @@ func TestUnhappyYamlKcmd(t *testing.T) {
 		{
 			// isolcpus: "a" is valid
 			Yaml: `
-kernel_cmdline:
+kernel-cmdline:
   isolcpus: "a"
   nohz: "on"
   nohz_full: "0-n"
@@ -168,7 +166,7 @@ kernel_cmdline:
 		{
 			// irqaffinity: "z" is valid
 			Yaml: `
-kernel_cmdline:
+kernel-cmdline:
   isolcpus: "0"
   nohz: "on"
   nohz_full: "0-n"
@@ -180,7 +178,7 @@ kernel_cmdline:
 		{
 			// nohz: "true" is valid it should be 'on' or 'off'
 			Yaml: `
-kernel_cmdline:
+kernel-cmdline:
   isolcpus: "0"
   nohz: "true"
   nohz_full: "0-n"
@@ -192,7 +190,7 @@ kernel_cmdline:
 		{
 			// isolcpus: "100000000" is invalid
 			Yaml: `
-kernel_cmdline:
+kernel-cmdline:
   isolcpus: "100000000"
   nohz: "off"
   nohz_full: "0-n"

--- a/src/model/pwrmgmt.go
+++ b/src/model/pwrmgmt.go
@@ -24,9 +24,9 @@ var scalProfilesMap = map[string]ScalProfiles{
 
 type CpuGovernanceRule struct {
 	CPUs    string `yaml:"cpus"`
-	ScalGov string `yaml:"scaling_governor"`
-	MinFreq string `yaml:"min_freq"`
-	MaxFreq string `yaml:"max_freq"`
+	ScalGov string `yaml:"scaling-governor"`
+	MinFreq string `yaml:"min-freq"`
+	MaxFreq string `yaml:"max-freq"`
 }
 
 func (c CpuGovernanceRule) Validate() error {


### PR DESCRIPTION
This adds support for tuning via snap configurations, primarily intended for seeding on Ubuntu Core to create images with tuning configurations.

- Change config field naming convention to kebab-case
- If snapped and snap options are set, override the config, per top level field. 
 
Only for non-persisted config: irq and cpu governance. Kernel command lines are left out on purpose to avoid confusion with [other two existing methods](https://documentation.ubuntu.com/core/how-to-guides/manage-ubuntu-core/modify-kernel-options/) on Ubuntu Core.

The loading of snap options can be changed such that it appends to existing rules instead of overriding the whole object. Maybe that is interesting during iterative tuning, allowing extensions or an override of a single parameter. However, that will add more room for confusion (e.g. unexpected partial overrides). Anyway, this can be easily be done via the config file as well so I don't see any added value. 


```console
$ sudo snap set rt-conf irq-tuning.test.cpus=0-1 irq-tuning.test.filter.actions=iwlwifi
$ sudo rt-conf 

-----------------------------
Applying Kernel command lines
-----------------------------
No kernel command line options to process

-------------------
Applying IRQ tuning
-------------------

Rule: test
+ Assigned IRQs 152-167 to CPUs 0-1

-----------------------
Applying CPU Governance
-----------------------
No CPU governance rules found in config
```

As JSON:
```console
$ sudo snap set rt-conf -t irq-tuning='{"test2": {
      "cpus": "2-3",
      "filter": {
        "actions": "iwlwifi"
      }
    }}'

$ sudo rt-conf 

-----------------------------
Applying Kernel command lines
-----------------------------
No kernel command line options to process

-------------------
Applying IRQ tuning
-------------------

Rule: test2
+ Assigned IRQs 152-167 to CPUs 2-3

-----------------------
Applying CPU Governance
-----------------------
No CPU governance rules found in config
```