### PR TITLE
feat: reject lowercase N on cpulists parsing

### DIFF
--- a/src/cpulists/parse.go
+++ b/src/cpulists/parse.go
@@ -40,9 +40,11 @@ func ParseForCPUs(cpuLists string, totalCPUs int) (CPUs, error) {
 			continue
 		}
 
-		// Handle "N" or "n"
+		// Handle "n"
+		if strings.Contains(item, "n") {
+			return nil, fmt.Errorf("lowercase N isn't accepted")
+		}
 		item = strings.ReplaceAll(item, "N", strconv.Itoa(totalCPUs-1))
-		item = strings.ReplaceAll(item, "n", strconv.Itoa(totalCPUs-1))
 
 		if strings.Contains(item, ":") {
 			if err := handleCPUGroup(item, cpus, totalCPUs); err != nil {

--- a/src/cpulists/parse_test.go
+++ b/src/cpulists/parse_test.go
@@ -26,6 +26,11 @@ func TestParseCPUListsHappy(t *testing.T) {
 			CPUs{0: true, 1: true},
 		},
 		{
+			"0-N",
+			2,
+			CPUs{0: true, 1: true},
+		},
+		{
 			"4",
 			8,
 			CPUs{4: true},
@@ -121,7 +126,7 @@ func TestParseCPUListsUnhappy(t *testing.T) {
 			"invalid end of range: all",
 		},
 		{
-			"all-n",
+			"all-N",
 			4,
 			"invalid start of range: all",
 		},
@@ -205,6 +210,11 @@ func TestParseCPUListsUnhappy(t *testing.T) {
 			8,
 			"used size greater than total CPUs: 9",
 		},
+		{
+			"0-n",
+			8,
+			"lowercase N isn't accepted",
+		},
 	}
 
 	// If not set totalCPUs back to the original function, the next tests will fail.
@@ -260,16 +270,16 @@ func TestParseWithFlagsHappy(t *testing.T) {
 		{"managed_irq,0", max, isolcpuFlags},
 
 		// Test comma separated CPU list
-		{"0,n", max, isolcpuFlags},
-		{"nohz,0,n", max, isolcpuFlags},
-		{"domain,0,n", max, isolcpuFlags},
-		{"managed_irq,0,n", max, isolcpuFlags},
+		{"0,N", max, isolcpuFlags},
+		{"nohz,0,N", max, isolcpuFlags},
+		{"domain,0,N", max, isolcpuFlags},
+		{"managed_irq,0,N", max, isolcpuFlags},
 
 		// Test comma separated CPU list
-		{"0,n", max, isolcpuFlags},
-		{"nohz,0,n", max, isolcpuFlags},
-		{"domain,0,n", max, isolcpuFlags},
-		{"managed_irq,0,n", max, isolcpuFlags},
+		{"0,N", max, isolcpuFlags},
+		{"nohz,0,N", max, isolcpuFlags},
+		{"domain,0,N", max, isolcpuFlags},
+		{"managed_irq,0,N", max, isolcpuFlags},
 	}
 
 	// If not set totalCPUs back to the original function, the next tests will fail.

--- a/src/model/irq_test.go
+++ b/src/model/irq_test.go
@@ -28,7 +28,7 @@ func TestIRQTuningValidate(t *testing.T) {
 		{
 			name: "valid regex",
 			c: IRQTuning{
-				CPUs: "0-n",
+				CPUs: "0-N",
 				Filter: IRQFilter{
 					Actions:  `nvme`,
 					ChipName: `-PCI-`,
@@ -41,7 +41,7 @@ func TestIRQTuningValidate(t *testing.T) {
 		{
 			name: "valid regex",
 			c: IRQTuning{
-				CPUs: "0,n",
+				CPUs: "0,N",
 				Filter: IRQFilter{
 					Actions:  `nvme`,
 					ChipName: `-PCI-`,

--- a/src/model/kcmdline_test.go
+++ b/src/model/kcmdline_test.go
@@ -92,21 +92,21 @@ func TestHappyYamlKcmd(t *testing.T) {
 		{
 			Yaml: `
 kernel-cmdline:
-  isolcpus: "0-n"
+  isolcpus: "0-N"
   nohz: "on"
-  nohz_full: "0-n"
-  kthread_cpus: "0-n"
-  irqaffinity: "0-n"
+  nohz_full: "0-N"
+  kthread_cpus: "0-N"
+  irqaffinity: "0-N"
 `,
 			Validations: []struct {
 				param string
 				value string
 			}{
-				{"isolcpus", "0-n"},
+				{"isolcpus", "0-N"},
 				{"nohz", "on"},
-				{"nohz_full", "0-n"},
-				{"kthread_cpus", "0-n"},
-				{"irqaffinity", "0-n"},
+				{"nohz_full", "0-N"},
+				{"kthread_cpus", "0-N"},
+				{"irqaffinity", "0-N"},
 			},
 		},
 		{
@@ -114,9 +114,9 @@ kernel-cmdline:
 kernel-cmdline:
   isolcpus: "0"
   nohz: "off"
-  nohz_full: "0-n"
-  kthread_cpus: "0-n"
-  irqaffinity: "0-n"
+  nohz_full: "0-N"
+  kthread_cpus: "0-N"
+  irqaffinity: "0-N"
 `,
 			Validations: []struct {
 				param string
@@ -124,9 +124,9 @@ kernel-cmdline:
 			}{
 				{"isolcpus", "0"},
 				{"nohz", "off"},
-				{"nohz_full", "0-n"},
-				{"kthread_cpus", "0-n"},
-				{"irqaffinity", "0-n"},
+				{"nohz_full", "0-N"},
+				{"kthread_cpus", "0-N"},
+				{"irqaffinity", "0-N"},
 			},
 		},
 	}
@@ -157,9 +157,9 @@ func TestUnhappyYamlKcmd(t *testing.T) {
 kernel-cmdline:
   isolcpus: "a"
   nohz: "on"
-  nohz_full: "0-n"
+  nohz_full: "0-N"
   kthread_cpus: "0"
-  irqaffinity: "0-n"
+  irqaffinity: "0-N"
 `,
 			Validations: nil,
 		},
@@ -169,9 +169,9 @@ kernel-cmdline:
 kernel-cmdline:
   isolcpus: "0"
   nohz: "on"
-  nohz_full: "0-n"
+  nohz_full: "0-N"
   kthread_cpus: "z"
-  irqaffinity: "0-n"
+  irqaffinity: "0-N"
 `,
 			Validations: nil,
 		},
@@ -181,9 +181,9 @@ kernel-cmdline:
 kernel-cmdline:
   isolcpus: "0"
   nohz: "true"
-  nohz_full: "0-n"
-  kthread_cpus: "0-n"
-  irqaffinity: "0-n"
+  nohz_full: "0-N"
+  kthread_cpus: "0-N"
+  irqaffinity: "0-N"
 `,
 			Validations: nil,
 		},
@@ -193,9 +193,9 @@ kernel-cmdline:
 kernel-cmdline:
   isolcpus: "100000000"
   nohz: "off"
-  nohz_full: "0-n"
-  kthread_cpus: "0-n"
-  irqaffinity: "0-n"
+  nohz_full: "0-N"
+  kthread_cpus: "0-N"
+  irqaffinity: "0-N"
 `,
 			Validations: nil,
 		},


### PR DESCRIPTION
- Lowercase N isn't part of cpu lists specification.
See: https://docs.kernel.org/admin-guide/kernel-parameters.html#cpu-lists

- test: update tests

- Fixes: https://github.com/canonical/rt-conf/issues/33