### PR TITLE
build: Switching yaml library to YAML.org supported go-yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/canonical/rt-conf
 
 go 1.22.2
 
-require gopkg.in/yaml.v3 v3.0.1
-
 require github.com/canonical/go-snapctl v1.0.0-beta.3
+
+require go.yaml.in/yaml/v3 v3.0.4

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/canonical/rt-conf
 
 go 1.22.2
 
-require github.com/canonical/go-snapctl v1.0.0-beta.3
-
-require go.yaml.in/yaml/v3 v3.0.4
+require (
+	github.com/canonical/go-snapctl v1.0.0-beta.3
+	go.yaml.in/yaml/v4 v4.0.0-rc.1
+)

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
-go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+go.yaml.in/yaml/v4 v4.0.0-rc.1 h1:4J1+yLKUIPGexM/Si+9d3pij4hdc7aGO04NhrElqXbY=
+go.yaml.in/yaml/v4 v4.0.0-rc.1/go.mod h1:CBdeces52/nUXndfQ5OY8GEQuNR9uEEOJPZj/Xq5IzU=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/model/config.go
+++ b/src/model/config.go
@@ -56,6 +56,7 @@ func (c *Config) LoadFromFile(confPath string) error {
 // LoadSnapOptions reads IRQ and CPU governance objects from snap options
 // When a value is set, the whole object gets overridden.
 func (c *Config) LoadSnapOptions() error {
+
 	value, err := snapctl.Get(
 		"kernel-cmdline",
 		"irq-tuning",

--- a/src/model/config.go
+++ b/src/model/config.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/canonical/go-snapctl"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var expectedPermission os.FileMode = 0o644
@@ -56,7 +56,6 @@ func (c *Config) LoadFromFile(confPath string) error {
 // LoadSnapOptions reads IRQ and CPU governance objects from snap options
 // When a value is set, the whole object gets overridden.
 func (c *Config) LoadSnapOptions() error {
-
 	value, err := snapctl.Get(
 		"kernel-cmdline",
 		"irq-tuning",

--- a/src/model/config.go
+++ b/src/model/config.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/canonical/go-snapctl"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 )
 
 var expectedPermission os.FileMode = 0o644
@@ -56,7 +56,6 @@ func (c *Config) LoadFromFile(confPath string) error {
 // LoadSnapOptions reads IRQ and CPU governance objects from snap options
 // When a value is set, the whole object gets overridden.
 func (c *Config) LoadSnapOptions() error {
-
 	value, err := snapctl.Get(
 		"kernel-cmdline",
 		"irq-tuning",

--- a/src/model/file.go
+++ b/src/model/file.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"regexp"
 
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type Grub struct {

--- a/src/model/file.go
+++ b/src/model/file.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"regexp"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type Grub struct {


### PR DESCRIPTION
https://github.com/yaml/go-yaml Is a maintained fork of https://github.com/go-yaml/yaml under YAML organization.

- Closes: https://github.com/canonical/rt-conf/issues/89