### PR TITLE
style: apply Go linter fixes and modernize syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sudo rt-conf
 
 Set `--help` for more details.
 
-The rt-conf app runs a oneshot service on system startup.
+The rt-conf app runs an oneshot service on system startup.
 This is useful for re-applying non-persistent IRQ tuning and power management settings on boot.
 
 By default, the service reads the [default configuration file](#default-configuration-file).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sudo rt-conf
 
 Set `--help` for more details.
 
-The rt-conf app runs an oneshot service on system startup.
+The rt-conf app runs a oneshot service on system startup.
 This is useful for re-applying non-persistent IRQ tuning and power management settings on boot.
 
 By default, the service reads the [default configuration file](#default-configuration-file).

--- a/cmd/rt-conf/main.go
+++ b/cmd/rt-conf/main.go
@@ -39,7 +39,9 @@ func run(args []string) error {
 		envVerbose,
 		"Verbose mode, prints more information to the console")
 
-	flags.Parse(args[1:])
+	if err := flags.Parse(args[1:]); err != nil {
+		return fmt.Errorf("failed to parse flags: %v", err)
+	}
 
 	log.SetFlags(0)
 

--- a/cmd/rt-conf/main_test.go
+++ b/cmd/rt-conf/main_test.go
@@ -17,7 +17,7 @@ func TestRunHappy(t *testing.T) {
 	tmpdir := t.TempDir()
 	configPath := filepath.Join(tmpdir, "config.yaml")
 
-	var testCases = []tests{
+	testCases := []tests{
 		{
 			name: "Valid empty config",
 			args: []string{"rt-conf", "-file", configPath},
@@ -32,7 +32,7 @@ irq-tuning:
 		t.Run(test.name, func(t *testing.T) {
 			if test.yaml != "" {
 				if err := os.WriteFile(configPath,
-					[]byte(test.yaml), 0644); err != nil {
+					[]byte(test.yaml), 0o644); err != nil {
 					t.Fatalf("failed to write file: %v", err)
 				}
 			}
@@ -55,7 +55,7 @@ func TestRunUnhappy(t *testing.T) {
 	tmpdir := t.TempDir()
 	configPath := filepath.Join(tmpdir, "config.yaml")
 
-	var testCases = []tests{
+	testCases := []tests{
 		{
 			name: "No config path",
 			args: []string{"rt-conf"},
@@ -121,7 +121,7 @@ cpu-governance:
 		t.Run(test.name, func(t *testing.T) {
 			if test.yaml != "" {
 				if err := os.WriteFile(configPath,
-					[]byte(test.yaml), 0644); err != nil {
+					[]byte(test.yaml), 0o644); err != nil {
 					t.Fatalf("failed to write file: %v", err)
 				}
 			}

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-go.yaml.in/yaml/v4 v4.0.0-rc.1 h1:4J1+yLKUIPGexM/Si+9d3pij4hdc7aGO04NhrElqXbY=
-go.yaml.in/yaml/v4 v4.0.0-rc.1/go.mod h1:CBdeces52/nUXndfQ5OY8GEQuNR9uEEOJPZj/Xq5IzU=
 go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
 go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ apps:
       - bin/export-env.sh
     command: bin/rt-conf
 
-  # Run the same app as an oneshot service
+  # Run the same app as a oneshot service
   d:
     <<: *rt-conf
     daemon: oneshot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ apps:
       - bin/export-env.sh
     command: bin/rt-conf
 
-  # Run the same app as a oneshot service
+  # Run the same app as an oneshot service
   d:
     <<: *rt-conf
     daemon: oneshot

--- a/src/cpulists/parse.go
+++ b/src/cpulists/parse.go
@@ -38,7 +38,7 @@ func ParseForCPUs(cpuLists string, totalCPUs int) (CPUs, error) {
 
 		// Handle "all"
 		if item == "all" {
-			for i := 0; i < totalCPUs; i++ {
+			for i := range totalCPUs {
 				cpus[i] = true
 			}
 			continue

--- a/src/cpulists/parse_test.go
+++ b/src/cpulists/parse_test.go
@@ -13,7 +13,7 @@ func TestParseCPUListsHappy(t *testing.T) {
 		output CPUs
 	}
 
-	var tst = []test{
+	tst := []test{
 		// single CPU
 		{
 			"all",
@@ -45,15 +45,19 @@ func TestParseCPUListsHappy(t *testing.T) {
 		{
 			"0-7",
 			10,
-			CPUs{0: true, 1: true, 2: true, 3: true, 4: true,
-				5: true, 6: true, 7: true},
+			CPUs{
+				0: true, 1: true, 2: true, 3: true, 4: true,
+				5: true, 6: true, 7: true,
+			},
 		},
 		// two CPUs ranges
 		{
 			"0-2,4-7",
 			10,
-			CPUs{0: true, 1: true, 2: true, 4: true,
-				5: true, 6: true, 7: true},
+			CPUs{
+				0: true, 1: true, 2: true, 4: true,
+				5: true, 6: true, 7: true,
+			},
 		},
 		// CPU range + single CPU
 		{
@@ -65,15 +69,19 @@ func TestParseCPUListsHappy(t *testing.T) {
 		{
 			"0-20:2/5",
 			24,
-			CPUs{0: true, 1: true, 5: true, 6: true,
-				10: true, 11: true, 15: true, 16: true, 20: true},
+			CPUs{
+				0: true, 1: true, 5: true, 6: true,
+				10: true, 11: true, 15: true, 16: true, 20: true,
+			},
 		},
 		// Formated CPU list + a single CPU
 		{
 			"0-20:2/5,23",
 			24,
-			CPUs{0: true, 1: true, 5: true, 6: true, 10: true,
-				11: true, 15: true, 16: true, 20: true, 23: true},
+			CPUs{
+				0: true, 1: true, 5: true, 6: true, 10: true,
+				11: true, 15: true, 16: true, 20: true, 23: true,
+			},
 		},
 	}
 
@@ -109,7 +117,7 @@ func TestParseCPUListsUnhappy(t *testing.T) {
 		err    string
 	}
 
-	var tst = []test{
+	tst := []test{
 		{
 			"al",
 			2,
@@ -233,7 +241,6 @@ func TestParseCPUListsUnhappy(t *testing.T) {
 		if err.Error() != expectedErr {
 			t.Fatalf("expected '%v', got '%v'", expectedErr, err)
 		}
-
 	})
 
 	for _, tt := range tst {
@@ -252,7 +259,7 @@ func TestParseCPUListsUnhappy(t *testing.T) {
 func TestParseWithFlagsHappy(t *testing.T) {
 	isolcpuFlags := []string{"domain", "nohz", "managed_irq"}
 	const max = 24
-	var testCases = []struct {
+	testCases := []struct {
 		value string
 		cpus  int
 		flags []string
@@ -315,7 +322,7 @@ func TestParseWithFlagsHappy(t *testing.T) {
 }
 
 func TestGenCPUlist(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name   string
 		cpus   []int
 		result string

--- a/src/cpulists/parse_test.go
+++ b/src/cpulists/parse_test.go
@@ -258,35 +258,35 @@ func TestParseCPUListsUnhappy(t *testing.T) {
 
 func TestParseWithFlagsHappy(t *testing.T) {
 	isolcpuFlags := []string{"domain", "nohz", "managed_irq"}
-	const max = 24
+	const maxCpus = 24
 	testCases := []struct {
 		value string
 		cpus  int
 		flags []string
 	}{
 		// Test CPU list with range
-		{"0-1", max, isolcpuFlags},
-		{"nohz,0-1", max, isolcpuFlags},
-		{"domain,0-1", max, isolcpuFlags},
-		{"managed_irq,0-1", max, isolcpuFlags},
+		{"0-1", maxCpus, isolcpuFlags},
+		{"nohz,0-1", maxCpus, isolcpuFlags},
+		{"domain,0-1", maxCpus, isolcpuFlags},
+		{"managed_irq,0-1", maxCpus, isolcpuFlags},
 
 		// Test single CPU on CPU list
-		{"0", max, isolcpuFlags},
-		{"nohz,0", max, isolcpuFlags},
-		{"domain,0", max, isolcpuFlags},
-		{"managed_irq,0", max, isolcpuFlags},
+		{"0", maxCpus, isolcpuFlags},
+		{"nohz,0", maxCpus, isolcpuFlags},
+		{"domain,0", maxCpus, isolcpuFlags},
+		{"managed_irq,0", maxCpus, isolcpuFlags},
 
 		// Test comma separated CPU list
-		{"0,N", max, isolcpuFlags},
-		{"nohz,0,N", max, isolcpuFlags},
-		{"domain,0,N", max, isolcpuFlags},
-		{"managed_irq,0,N", max, isolcpuFlags},
+		{"0,N", maxCpus, isolcpuFlags},
+		{"nohz,0,N", maxCpus, isolcpuFlags},
+		{"domain,0,N", maxCpus, isolcpuFlags},
+		{"managed_irq,0,N", maxCpus, isolcpuFlags},
 
 		// Test comma separated CPU list
-		{"0,N", max, isolcpuFlags},
-		{"nohz,0,N", max, isolcpuFlags},
-		{"domain,0,N", max, isolcpuFlags},
-		{"managed_irq,0,N", max, isolcpuFlags},
+		{"0,N", maxCpus, isolcpuFlags},
+		{"nohz,0,N", maxCpus, isolcpuFlags},
+		{"domain,0,N", maxCpus, isolcpuFlags},
+		{"managed_irq,0,N", maxCpus, isolcpuFlags},
 	}
 
 	// If not set totalCPUs back to the original function, the next tests will fail.

--- a/src/cpulists/total_test.go
+++ b/src/cpulists/total_test.go
@@ -24,7 +24,7 @@ func TestTotalCPUsUnhappy(t *testing.T) {
 		expectErr  string
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			name:       "command error",
 			mockOutput: nil,

--- a/src/irq/irq.go
+++ b/src/irq/irq.go
@@ -36,7 +36,7 @@ import (
 // https://wiki.linuxfoundation.org/realtime/documentation/howto/debugging/smi-latency/smi
 
 // ** From experiments:
-// ** Non active IRQs (not shown in /proc/interrupts) are the ones which
+// ** Non-active IRQs (not shown in /proc/interrupts) are the ones which
 // ** doesn't have an action (/sys/kernel/irq/<num>/action) associated with them
 
 type IRQs map[int]bool // use the same logic as CPUs lists

--- a/src/irq/irq.go
+++ b/src/irq/irq.go
@@ -44,8 +44,10 @@ type IRQs map[int]bool // use the same logic as CPUs lists
 // realIRQReaderWriter writes CPU affinity to the real `/proc/irq/<irq>/smp_affinity_list` file.
 type realIRQReaderWriter struct{}
 
-var procIRQ = model.ProcIRQ
-var sysKernelIRQ = model.SysKernelIRQ
+var (
+	procIRQ      = model.ProcIRQ
+	sysKernelIRQ = model.SysKernelIRQ
+)
 
 var writeFile = func(path string, content []byte, perm os.FileMode) error {
 	return os.WriteFile(path, content, perm)
@@ -59,7 +61,7 @@ var writeFile = func(path string, content []byte, perm os.FileMode) error {
 // - err: error if any occurred nil if no error occurred
 func (w *realIRQReaderWriter) WriteCPUAffinity(irqNum int, cpus string) (success bool, managedIRQ bool, err error) {
 	affinityFile := fmt.Sprintf("%s/%d/smp_affinity_list", procIRQ, irqNum)
-	err = writeFile(affinityFile, []byte(cpus), 0644)
+	err = writeFile(affinityFile, []byte(cpus), 0o644)
 	if err != nil {
 		if strings.Contains(err.Error(), "input/output error") {
 			return false, true, nil
@@ -150,7 +152,6 @@ func applyIRQConfig(
 	config *model.InternalConfig,
 	handler IRQReaderWriter,
 ) error {
-
 	irqs, err := handler.ReadIRQs()
 	if err != nil {
 		return err
@@ -245,7 +246,6 @@ func logChanges(changed, managed []int, cpuList cpulists.CPUs, cpus string) {
 	if len(managed) > 0 {
 		msgs = append(msgs, fmt.Sprintf("Ignored managed IRQs: %s",
 			cpulists.GenCPUlist(managed)))
-
 	}
 	utils.LogTreeStyle(msgs)
 }

--- a/src/irq/irq.go
+++ b/src/irq/irq.go
@@ -56,7 +56,7 @@ var writeFile = func(path string, content []byte, perm os.FileMode) error {
 // Write IRQ affinity
 
 // returns:
-// - sucess: true if the affinity was written successfully false if not
+// - success: true if the affinity was written successfully false if not
 // - managedIRQ: true if the irqNum was a managed (read-only) IRQ false if not
 // - err: error if any occurred nil if no error occurred
 func (w *realIRQReaderWriter) WriteCPUAffinity(irqNum int, cpus string) (success bool, managedIRQ bool, err error) {

--- a/src/irq/irq_test.go
+++ b/src/irq/irq_test.go
@@ -30,7 +30,8 @@ func (m *mockIRQReaderWriter) ReadIRQs() ([]IRQInfo, error) {
 }
 
 func (m *mockIRQReaderWriter) WriteCPUAffinity(irqNum int, cpus string) (
-	success bool, managed bool, err error) {
+	success bool, managed bool, err error,
+) {
 	if err, ok := m.Errors["WriteCPUAffinity"]; ok {
 		return false, false, err
 	}
@@ -49,8 +50,7 @@ type IRQTestCase struct {
 }
 
 func TestHappyIRQtuning(t *testing.T) {
-
-	var happyCases = []IRQTestCase{
+	happyCases := []IRQTestCase{
 		{
 			Yaml: `
 irq-tuning:
@@ -96,8 +96,7 @@ irq_tuning:
 }
 
 func TestUnhappyIRQtuning(t *testing.T) {
-
-	var UnhappyCases = []IRQTestCase{
+	UnhappyCases := []IRQTestCase{
 		{
 			// Invalid number
 			Yaml: `
@@ -134,7 +133,7 @@ irq-tuning:
 func setupTempFile(t *testing.T, content string, idex int) string {
 	t.Helper()
 	tmpfileName := fmt.Sprintf("tempfile-%d", idex)
-	err := os.WriteFile(tmpfileName, []byte(content), 0644)
+	err := os.WriteFile(tmpfileName, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temporary file: %v", err)
 	}
@@ -164,7 +163,7 @@ func TestWriteCPUAffinitySuccessfulWrite(t *testing.T) {
 	irqNum := 1
 	cpus := "0-3"
 	irqPath := filepath.Join(tmpDir, fmt.Sprintf("%d", irqNum))
-	if err := os.MkdirAll(irqPath, 0755); err != nil {
+	if err := os.MkdirAll(irqPath, 0o755); err != nil {
 		t.Fatalf("failed to create IRQ directory: %v", err)
 	}
 	affinityFile := filepath.Join(irqPath, "smp_affinity_list")
@@ -225,17 +224,16 @@ func TestWriteCPUAffinityAlreadySet(t *testing.T) {
 	irqNum := 5
 	cpus := "0"
 	irqPath := filepath.Join(tmpDir, fmt.Sprintf("%d", irqNum))
-	if err := os.MkdirAll(irqPath, 0755); err != nil {
+	if err := os.MkdirAll(irqPath, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	affinityFile := filepath.Join(irqPath, "smp_affinity_list")
-	if err := os.WriteFile(affinityFile, []byte(cpus), 0644); err != nil {
+	if err := os.WriteFile(affinityFile, []byte(cpus), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	writer := &realIRQReaderWriter{}
 	_, _, err := writer.WriteCPUAffinity(irqNum, cpus)
-
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
@@ -254,17 +252,18 @@ func setupIRQTestDir(t *testing.T, entries []irqDirEntry) string {
 
 	for _, e := range entries {
 		dir := filepath.Join(tmpDir, strconv.Itoa(e.Number))
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("failed to create dir: %v", err)
 		}
 		for name, content := range e.Files {
-			if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
 				t.Fatalf("failed to write file: %v", err)
 			}
 		}
 	}
 	return tmpDir
 }
+
 func TestReadIRQsSingleActiveIRQ(t *testing.T) {
 	setupIRQTestDir(t, []irqDirEntry{
 		{
@@ -315,7 +314,7 @@ func TestReadIRQsEmptyActionsIgnored(t *testing.T) {
 func TestReadIRQsNonNumericDirectoryIgnored(t *testing.T) {
 	tmp := t.TempDir()
 	sysKernelIRQ = tmp
-	_ = os.Mkdir(filepath.Join(tmp, "notanumber"), 0755)
+	_ = os.Mkdir(filepath.Join(tmp, "notanumber"), 0o755)
 
 	r := &realIRQReaderWriter{}
 	irqs, err := r.ReadIRQs()

--- a/src/irq/irq_test.go
+++ b/src/irq/irq_test.go
@@ -143,7 +143,9 @@ func setupTempFile(t *testing.T, content string, idex int) string {
 func mainLogicIRQ(t *testing.T, cfg IRQTestCase, i int) (string, error) {
 	tempConfigPath := setupTempFile(t, cfg.Yaml, i)
 	t.Cleanup(func() {
-		os.Remove(tempConfigPath)
+		if err := os.Remove(tempConfigPath); err != nil {
+			t.Fatalf("Failed to remove temporary file: %v", err)
+		}
 	})
 	var conf model.InternalConfig
 	if err := conf.Data.LoadFromFile(tempConfigPath); err != nil {
@@ -171,7 +173,9 @@ func TestWriteCPUAffinitySuccessfulWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create file: %v", err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close file: %v", err)
+	}
 
 	procIRQ = tmpDir // override to avoid touching /proc
 	writer := &realIRQReaderWriter{}

--- a/src/kcmd/conclusion_test.go
+++ b/src/kcmd/conclusion_test.go
@@ -8,14 +8,14 @@ func TestGrubConclusion(t *testing.T) {
 	green := "\033[32m"
 	reset := "\033[0m"
 	old := "quiet splash"
-	new := "quiet splash isolcpus=1-2"
+	latest := "quiet splash isolcpus=1-2"
 
 	expected := []string{
 		"Detected bootloader: GRUB\n",
 		"Default kernel command line:\n",
 		red + "-  " + old + reset + "\n",
 		"New kernel command line:\n",
-		green + "+  " + new + reset + "\n",
+		green + "+  " + latest + reset + "\n",
 		"Updated default grub file: " + grubFile + "\n",
 		"\n",
 		"Please run:\n",
@@ -26,7 +26,7 @@ func TestGrubConclusion(t *testing.T) {
 		"\n",
 	}
 
-	result := GrubConclusion(grubFile, old, new)
+	result := GrubConclusion(grubFile, old, latest)
 
 	if len(result) != len(expected) {
 		t.Errorf("Expected %d lines, got %d", len(expected), len(result))

--- a/src/kcmd/grub.go
+++ b/src/kcmd/grub.go
@@ -67,11 +67,7 @@ func ParseDefaultGrubFile(f string) (params map[string]string, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %s: %v", f, err)
 	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil && err == nil {
-			err = fmt.Errorf("error closing %s: %v", f, closeErr)
-		}
-	}()
+	defer file.Close()
 
 	params = make(map[string]string)
 	scanner := bufio.NewScanner(file)

--- a/src/kcmd/grub.go
+++ b/src/kcmd/grub.go
@@ -109,7 +109,7 @@ func ParseDefaultGrubFile(f string) (params map[string]string, err error) {
 		return nil, fmt.Errorf("error reading grub file %s: %v", f, err)
 	}
 
-	return params, nil
+	return params, err
 }
 
 // processFile writes the GRUB configuration to the specified file.

--- a/src/kcmd/grub.go
+++ b/src/kcmd/grub.go
@@ -62,14 +62,16 @@ func parseGrubCMDLineLinuxDefault(path string) (string, error) {
 }
 
 // ParseDefaultGrubFile parses a GRUB default configuration file into key-value pairs.
-func ParseDefaultGrubFile(f string) (map[string]string, error) {
+func ParseDefaultGrubFile(f string) (params map[string]string, err error) {
 	file, err := os.Open(f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %s: %v", f, err)
 	}
-	defer file.Close()
+	defer func(f *os.File) {
+		err = f.Close()
+	}(file)
 
-	params := make(map[string]string)
+	params = make(map[string]string)
 	scanner := bufio.NewScanner(file)
 	lineNum := 0
 

--- a/src/kcmd/grub.go
+++ b/src/kcmd/grub.go
@@ -67,9 +67,11 @@ func ParseDefaultGrubFile(f string) (params map[string]string, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %s: %v", f, err)
 	}
-	defer func(f *os.File) {
-		err = f.Close()
-	}(file)
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("error closing %s: %v", f, closeErr)
+		}
+	}()
 
 	params = make(map[string]string)
 	scanner := bufio.NewScanner(file)

--- a/src/kcmd/grub_test.go
+++ b/src/kcmd/grub_test.go
@@ -185,7 +185,9 @@ func TestParseGrubFile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpFile := setupTempFile(t, tc.content, i)
 			t.Cleanup(func() {
-				os.Remove(tmpFile)
+				if err := os.Remove(tmpFile); err != nil {
+					t.Fatalf("Failed to remove temporary file: %v", err)
+				}
 			})
 
 			params, err := ParseDefaultGrubFile(tmpFile)
@@ -352,9 +354,13 @@ func TestUpdateGrub(t *testing.T) {
 			}
 
 			// If test needs Parse failure, remove the file
-			if tc.name == "ParseDefaultGrubFile fails" {
-				os.Remove(grubDefaultPath)
-				os.Remove(cfgPath)
+			if tc.name == "ParseDefaultGrubFile fails" && tc.grubContent != "" {
+				if err := os.Remove(grubDefaultPath); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Remove(cfgPath); err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			conf := &model.InternalConfig{

--- a/src/kcmd/uc.go
+++ b/src/kcmd/uc.go
@@ -87,7 +87,10 @@ func UpdateUbuntuCore(cfg *model.InternalConfig) ([]string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 
 	var snapResp SnapdResponse
 	if err := json.Unmarshal(body, &snapResp); err != nil {

--- a/src/model/config_test.go
+++ b/src/model/config_test.go
@@ -13,7 +13,7 @@ func TestIsOwnedByRoot(t *testing.T) {
 	tmpdir := t.TempDir()
 	filePath := filepath.Join(tmpdir, "testfile")
 	err := os.WriteFile(filePath,
-		[]byte("test"), 0644)
+		[]byte("test"), 0o644)
 	if err != nil {
 		t.Fatalf("failed to create test file: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestIsOwnedByRoot(t *testing.T) {
 }
 
 func TestLoadConfigFile(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name        string
 		yaml        string
 		perm        os.FileMode
@@ -38,7 +38,7 @@ func TestLoadConfigFile(t *testing.T) {
 		{
 			name:        "FileDoesNotExist",
 			yaml:        "",
-			perm:        0644,
+			perm:        0o644,
 			cfg:         nil,
 			err:         fmt.Errorf("failed to find file"),
 			ownedByRoot: true,
@@ -46,7 +46,7 @@ func TestLoadConfigFile(t *testing.T) {
 		{
 			name:        "FileInvalidPermissions",
 			yaml:        "kernel-cmdline:",
-			perm:        0755,
+			perm:        0o755,
 			cfg:         nil,
 			err:         fmt.Errorf("has invalid permissions"),
 			ownedByRoot: true,
@@ -54,7 +54,7 @@ func TestLoadConfigFile(t *testing.T) {
 		{
 			name:        "FileNotOwnedByRoot",
 			yaml:        `kernel-cmdline:`,
-			perm:        0644,
+			perm:        0o644,
 			cfg:         nil,
 			err:         fmt.Errorf("not owned by root"),
 			ownedByRoot: false,
@@ -62,7 +62,7 @@ func TestLoadConfigFile(t *testing.T) {
 		{
 			name:        "FailedToUnmarshalYAML",
 			yaml:        `kernel-cmdline: {`,
-			perm:        0644,
+			perm:        0o644,
 			cfg:         nil,
 			err:         fmt.Errorf("failed to unmarshal data"),
 			ownedByRoot: true,
@@ -77,7 +77,7 @@ kernel-cmdline:
     - kthread_cpus=0
     - irqaffinity=0
 `,
-			perm: 0644,
+			perm: 0o644,
 			cfg: &Config{
 				KernelCmdline: KernelCmdline{
 					Parameters: []string{

--- a/src/model/data.go
+++ b/src/model/data.go
@@ -11,8 +11,10 @@ type InternalConfig struct {
 	GrubCfg Grub
 }
 
-type PwrMgmt map[string]CpuGovernanceRule
-type Interrupts map[string]IRQTuning
+type (
+	PwrMgmt    map[string]CpuGovernanceRule
+	Interrupts map[string]IRQTuning
+)
 
 type Config struct {
 	KernelCmdline KernelCmdline `yaml:"kernel-cmdline"`

--- a/src/model/file_test.go
+++ b/src/model/file_test.go
@@ -74,7 +74,7 @@ kernel-cmdline:
 				filePath = filepath.Join(tmpdir, "nonexistent.yaml")
 			} else {
 				filePath = filepath.Join(tmpdir, tc.name+".yaml")
-				if err := os.WriteFile(filePath, []byte(tc.yaml), 0644); err != nil {
+				if err := os.WriteFile(filePath, []byte(tc.yaml), 0o644); err != nil {
 					t.Fatalf("failed to write test YAML file: %v", err)
 				}
 			}

--- a/src/model/irq.go
+++ b/src/model/irq.go
@@ -55,8 +55,8 @@ func (c IRQFilter) Validate() error {
 // TODO: Validate mutual exclusive cpu lists
 
 func (c IRQFilter) validateIRQField(name string, value string, tag string) error {
-	switch {
-	case tag == "cpulist":
+	switch tag {
+	case "cpulist":
 		num, err := GetHigherIRQ()
 		if err != nil {
 			return err
@@ -66,7 +66,7 @@ func (c IRQFilter) validateIRQField(name string, value string, tag string) error
 			return fmt.Errorf("on field %v: invalid irq list: %v", name,
 				err)
 		}
-	case tag == "regex":
+	case "regex":
 		_, err := regexp.Compile(value)
 		if err != nil {
 			return fmt.Errorf("on field %v: invalid regex: %v", name, err)

--- a/src/model/irq_test.go
+++ b/src/model/irq_test.go
@@ -86,12 +86,15 @@ type mockDirEntry struct {
 func (m *mockDirEntry) Name() string {
 	return m.name
 }
+
 func (m *mockDirEntry) IsDir() bool {
 	return m.isDir
 }
+
 func (m *mockDirEntry) Type() os.FileMode {
 	return os.ModeDir
 }
+
 func (m *mockDirEntry) Info() (os.FileInfo, error) {
 	return nil, nil
 }

--- a/src/model/kcmdline_test.go
+++ b/src/model/kcmdline_test.go
@@ -50,9 +50,15 @@ func mainLogic(t *testing.T, c TestCase, i int) (string, error) {
 	}
 
 	t.Cleanup(func() {
-		os.Remove(tempConfigPath)
-		os.Remove(tempGrubPath)
-		os.Remove(tempCustomCfgPath)
+		if err := os.Remove(tempConfigPath); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(tempGrubPath); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(tempCustomCfgPath); err != nil {
+			t.Fatal(err)
+		}
 	})
 
 	t.Logf("tempConfigPath: %s\n", tempConfigPath)

--- a/src/model/kcmdline_test.go
+++ b/src/model/kcmdline_test.go
@@ -45,7 +45,7 @@ func mainLogic(t *testing.T, c TestCase, i int) (string, error) {
 
 	// Setup temporary custom grub config file
 	tempCustomCfgPath := filepath.Join(dir, fmt.Sprintf("rt-conf-%d.cfg", i))
-	if err := os.WriteFile(tempGrubPath, []byte(grubSample), 0o644); err != nil {
+	if err := os.WriteFile(tempCustomCfgPath, []byte(grubSample), 0o644); err != nil {
 		t.Fatalf("failed to write grub: %v", err)
 	}
 

--- a/src/model/pwrmgmt.go
+++ b/src/model/pwrmgmt.go
@@ -38,16 +38,16 @@ func (c CpuGovernanceRule) Validate() error {
 		return fmt.Errorf("invalid cpu scaling governor: %v", c.ScalGov)
 	}
 
-	min, err := ParseFreq(c.MinFreq)
+	minFreq, err := ParseFreq(c.MinFreq)
 	if err != nil {
 		return fmt.Errorf("invalid min frequency: %v", err)
 	}
-	max, err := ParseFreq(c.MaxFreq)
+	maxFreq, err := ParseFreq(c.MaxFreq)
 	if err != nil {
 		return fmt.Errorf("invalid max frequency: %v", err)
 	}
 
-	if err := validateFreqRange(min, max); err != nil {
+	if err := validateFreqRange(minFreq, maxFreq); err != nil {
 		return fmt.Errorf("invalid frequency range: %v", err)
 	}
 

--- a/src/model/pwrmgmt_test.go
+++ b/src/model/pwrmgmt_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPwrMgmtValidationHappy(t *testing.T) {
-	var happyCases = []CpuGovernanceRule{
+	happyCases := []CpuGovernanceRule{
 		{
 			CPUs:    "0",
 			ScalGov: "balanced",
@@ -31,7 +31,7 @@ func TestPwrMgmtValidationHappy(t *testing.T) {
 }
 
 func TestPwrMgmtValidationUnhappy(t *testing.T) {
-	var happyCases = []struct {
+	happyCases := []struct {
 		err    string
 		sclgov CpuGovernanceRule
 	}{
@@ -66,12 +66,11 @@ func TestPwrMgmtValidationUnhappy(t *testing.T) {
 			if err.Error() != tc.err {
 				t.Fatalf("Expected error message: %q, got: %q", tc.err, err)
 			}
-
 		})
 	}
 }
 
-func TestCheckFreqFormat(t *testing.T) { //TODO: drop this test
+func TestCheckFreqFormat(t *testing.T) { // TODO: drop this test
 	tests := []struct {
 		name    string
 		rule    CpuGovernanceRule

--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -28,7 +28,12 @@ func writeOnly(path string, data string) error {
 	if err != nil {
 		return fmt.Errorf("error opening %s: %v", path, err)
 	}
-	defer f.Close()
+	defer func(f *os.File) error {
+		if err := f.Close(); err != nil {
+			return err
+		}
+		return nil
+	}(f)
 
 	_, err = f.Write([]byte(data))
 	if err != nil {

--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -23,17 +23,16 @@ var pwrmgmtReaderWriter = ReaderWriter{
 	MaxFreqPath:         "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_max_freq",
 }
 
-func writeOnly(path string, data string) error {
+func writeOnly(path string, data string) (err error) {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
 	if err != nil {
 		return fmt.Errorf("error opening %s: %v", path, err)
 	}
-	defer func(f *os.File) error {
-		if err := f.Close(); err != nil {
-			return err
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("error closing %s: %v", path, closeErr)
 		}
-		return nil
-	}(f)
+	}()
 
 	_, err = f.Write([]byte(data))
 	if err != nil {

--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -23,7 +23,7 @@ var pwrmgmtReaderWriter = ReaderWriter{
 	MaxFreqPath:         "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_max_freq",
 }
 
-func writeOnly(path string, data string) (err error) {
+func writeOnly(path string, data string) error {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
 	if err != nil {
 		return fmt.Errorf("error opening %s: %v", path, err)

--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -28,11 +28,7 @@ func writeOnly(path string, data string) (err error) {
 	if err != nil {
 		return fmt.Errorf("error opening %s: %v", path, err)
 	}
-	defer func() {
-		if closeErr := f.Close(); closeErr != nil && err == nil {
-			err = fmt.Errorf("error closing %s: %v", path, closeErr)
-		}
-	}()
+	defer f.Close()
 
 	_, err = f.Write([]byte(data))
 	if err != nil {

--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -83,7 +83,6 @@ func ApplyPwrConfig(config *model.InternalConfig) error {
 func (wr ReaderWriter) applyPwrConfig(
 	rules model.PwrMgmt,
 ) error {
-
 	// Range over all CPU governance rules
 	for label, sclgov := range rules {
 
@@ -136,7 +135,8 @@ func logChanges(cpus []int, minFreq, maxFreq, scalingGov string) {
 }
 
 func (wr ReaderWriter) applyRule(cpu int,
-	sclgov model.CpuGovernanceRule) error {
+	sclgov model.CpuGovernanceRule,
+) error {
 	if err := wr.WriteScalingGov(sclgov.ScalGov, cpu); err != nil {
 		return err
 	}

--- a/src/pwr_mgmt/pwr.go
+++ b/src/pwr_mgmt/pwr.go
@@ -139,9 +139,7 @@ func logChanges(cpus []int, minFreq, maxFreq, scalingGov string) {
 	utils.LogTreeStyle(msg)
 }
 
-func (wr ReaderWriter) applyRule(cpu int,
-	sclgov model.CpuGovernanceRule,
-) error {
+func (wr ReaderWriter) applyRule(cpu int, sclgov model.CpuGovernanceRule) error {
 	if err := wr.WriteScalingGov(sclgov.ScalGov, cpu); err != nil {
 		return err
 	}

--- a/src/pwr_mgmt/pwr_test.go
+++ b/src/pwr_mgmt/pwr_test.go
@@ -25,7 +25,9 @@ func setupTempDirWithFiles(t *testing.T, prvRule string, maxCpus int) string {
 
 	// Clean up the temp directory after the test finishes.
 	t.Cleanup(func() {
-		os.RemoveAll(tempDir)
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("failed to remove temp directory: %v", err)
+		}
 	})
 
 	// Create files from 0 to n-1.
@@ -50,7 +52,9 @@ func setupTempDirWithFiles(t *testing.T, prvRule string, maxCpus int) string {
 			t.Fatalf("number of written bytes doesn't match on file %s",
 				scalGov)
 		}
-		fscalGov.Close()
+		if err := fscalGov.Close(); err != nil {
+			t.Fatalf("failed to close file %s: %v", scalGov, err)
+		}
 
 		for _, file := range []string{"maxfreq", "minfreq"} {
 			filePath := filepath.Join(cpuPath, file)

--- a/src/pwr_mgmt/pwr_test.go
+++ b/src/pwr_mgmt/pwr_test.go
@@ -32,7 +32,7 @@ func setupTempDirWithFiles(t *testing.T, prvRule string, maxCpus int) string {
 	for i := 0; i < maxCpus; i++ {
 		filename := strconv.Itoa(i)
 		cpuPath := filepath.Join(tempDir, filename)
-		if err := os.Mkdir(cpuPath, 0755); err != nil {
+		if err := os.Mkdir(cpuPath, 0o755); err != nil {
 			t.Fatalf("failed to create directory %s: %v", cpuPath, err)
 		}
 
@@ -54,7 +54,7 @@ func setupTempDirWithFiles(t *testing.T, prvRule string, maxCpus int) string {
 
 		for _, file := range []string{"maxfreq", "minfreq"} {
 			filePath := filepath.Join(cpuPath, file)
-			if err := os.WriteFile(filePath, []byte("0"), 0644); err != nil {
+			if err := os.WriteFile(filePath, []byte("0"), 0o644); err != nil {
 				t.Fatalf("failed to create file %s: %v", filePath, err)
 			}
 		}
@@ -67,7 +67,7 @@ func TestPwrMgmt(t *testing.T) {
 	// Since this considers the real amount of cpus in the system, all cpulists
 	// for CpuGovernanceRule.CPUs are set to 0 so it can be tested with any
 	// amount of cpus
-	var happyCases = []struct {
+	happyCases := []struct {
 		name     string
 		maxCpus  int
 		prevRule string
@@ -183,7 +183,6 @@ func TestPwrMgmt(t *testing.T) {
 
 	for index, tc := range happyCases {
 		t.Run(fmt.Sprintf("case-%d", index), func(t *testing.T) {
-
 			basePath := setupTempDirWithFiles(t, tc.prevRule, tc.maxCpus)
 
 			// Create a new ReaderWriter instance with the base path
@@ -215,11 +214,10 @@ func TestPwrMgmt(t *testing.T) {
 				}
 
 			}
-
 		})
 	}
 
-	var UnhappyCases = []struct {
+	UnhappyCases := []struct {
 		name string
 		cfg  *model.InternalConfig
 		err  error
@@ -253,7 +251,7 @@ func TestPwrMgmt(t *testing.T) {
 }
 
 func TestEmptyPwrMgmtRules(t *testing.T) {
-	var errorCases = []struct {
+	errorCases := []struct {
 		name string
 		cfg  *model.InternalConfig
 	}{
@@ -369,7 +367,7 @@ func TestWriteOnly(t *testing.T) {
 			name: "success",
 			prepare: func(path string) {
 				// Create the file with write permission
-				_ = os.WriteFile(path, []byte("old content"), 0644)
+				_ = os.WriteFile(path, []byte("old content"), 0o644)
 			},
 			path:        filepath.Join(tmpDir, "success.txt"),
 			data:        "new data",
@@ -387,7 +385,7 @@ func TestWriteOnly(t *testing.T) {
 		{
 			name: "fail to write (read-only file)",
 			prepare: func(path string) {
-				_ = os.WriteFile(path, []byte("content"), 0444) // Read-only
+				_ = os.WriteFile(path, []byte("content"), 0o444) // Read-only
 			},
 			path:        filepath.Join(tmpDir, "readonly.txt"),
 			data:        "",
@@ -450,7 +448,6 @@ func TestApplyRuleUnhappy(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			err := pwrmgmtReaderWriter.applyRule(0, tc.sclgov)
 			if err == nil {
 				t.Fatalf(

--- a/src/pwr_mgmt/pwr_test.go
+++ b/src/pwr_mgmt/pwr_test.go
@@ -29,7 +29,7 @@ func setupTempDirWithFiles(t *testing.T, prvRule string, maxCpus int) string {
 	})
 
 	// Create files from 0 to n-1.
-	for i := 0; i < maxCpus; i++ {
+	for i := range maxCpus {
 		filename := strconv.Itoa(i)
 		cpuPath := filepath.Join(tempDir, filename)
 		if err := os.Mkdir(cpuPath, 0o755); err != nil {

--- a/src/system/system_test.go
+++ b/src/system/system_test.go
@@ -6,9 +6,13 @@ import (
 )
 
 func TestDetectSystemUbuntuCore(t *testing.T) {
-	os.Setenv("SNAP_SAVE_DATA", "/some/uc/path")
+	if err := os.Setenv("SNAP_SAVE_DATA", "/some/uc/path"); err != nil {
+		t.Fatalf("failed to set env: %v", err)
+	}
 	t.Cleanup(func() {
-		os.Unsetenv("SNAP_SAVE_DATA")
+		if err := os.Unsetenv("SNAP_SAVE_DATA"); err != nil {
+			t.Fatalf("failed to unset env: %v", err)
+		}
 	})
 
 	sys, err := DetectSystem()
@@ -21,7 +25,9 @@ func TestDetectSystemUbuntuCore(t *testing.T) {
 }
 
 func TestDetectSystemGrub(t *testing.T) {
-	os.Unsetenv("SNAP_SAVE_DATA")
+	if err := os.Unsetenv("SNAP_SAVE_DATA"); err != nil {
+		t.Fatalf("failed to unset env: %v", err)
+	}
 
 	tmpGrub := "/tmp/default/grub"
 	if err := os.MkdirAll("/tmp/default", 0o755); err != nil {
@@ -30,7 +36,11 @@ func TestDetectSystemGrub(t *testing.T) {
 	if err := os.WriteFile(tmpGrub, []byte("GRUB_CMDLINE"), 0o644); err != nil {
 		t.Fatalf("failed to write grub file: %v", err)
 	}
-	defer os.Remove(tmpGrub)
+	t.Cleanup(func() {
+		if err := os.Remove(tmpGrub); err != nil {
+			t.Fatal("failed to remove tmp grub file:", err)
+		}
+	})
 
 	sys, err := DetectSystem()
 	if err != nil {

--- a/src/system/system_test.go
+++ b/src/system/system_test.go
@@ -24,10 +24,10 @@ func TestDetectSystemGrub(t *testing.T) {
 	os.Unsetenv("SNAP_SAVE_DATA")
 
 	tmpGrub := "/tmp/default/grub"
-	if err := os.MkdirAll("/tmp/default", 0755); err != nil {
+	if err := os.MkdirAll("/tmp/default", 0o755); err != nil {
 		t.Fatalf("failed to mkdir: %v", err)
 	}
-	if err := os.WriteFile(tmpGrub, []byte("GRUB_CMDLINE"), 0644); err != nil {
+	if err := os.WriteFile(tmpGrub, []byte("GRUB_CMDLINE"), 0o644); err != nil {
 		t.Fatalf("failed to write grub file: %v", err)
 	}
 	defer os.Remove(tmpGrub)


### PR DESCRIPTION
## Description
- Convert var declarations to short variable syntax (:=)
- Use modern octal literal format (0o prefix)
- Simplify range loops where appropriate
- Refactor switch statements for better readability
- Normalize struct literal formatting and blank line spacing
- Apply automated linter and gofmt fixes

## Checklist
 - ~~[ ] Added tests for new functionality~~ Already exists
 - ~~[ ] Checked / updated the README~~ Not necessary
 - ~~[ ] Checked / updated Real-time Ubuntu docs~~Not necessary
<!-- For external docs changes, provide the URL -->
