### PR TITLE
fix: handle error when parsing VERBOSE env variable

### DIFF
--- a/cmd/rt-conf/main.go
+++ b/cmd/rt-conf/main.go
@@ -23,10 +23,14 @@ func main() {
 
 func run(args []string) error {
 	envConfigFile := os.Getenv("CONFIG_FILE")
-	envVerbose, err := strconv.ParseBool(os.Getenv("VERBOSE"))
-	if err != nil {
-		log.Printf("Warning: failed to parse VERBOSE env var, defaulting to false: %v", err)
-		envVerbose = false
+	verboseDefaultCfg := false
+	var err error
+	envVerbose, ok := os.LookupEnv("VERBOSE")
+	if ok {
+		verboseDefaultCfg, err = strconv.ParseBool(envVerbose)
+		if err != nil {
+			return err
+		}
 	}
 
 	flags := flag.NewFlagSet(args[0], flag.ExitOnError)
@@ -40,7 +44,7 @@ func run(args []string) error {
 		"/etc/default/grub.d/60_rt-conf.cfg",
 		"Path to the output drop-in grub configuration file, relevant only for GRUB bootloader")
 	verbose := flags.Bool("verbose",
-		envVerbose,
+		verboseDefaultCfg,
 		"Verbose mode, prints more information to the console")
 
 	if err := flags.Parse(args[1:]); err != nil {

--- a/cmd/rt-conf/main.go
+++ b/cmd/rt-conf/main.go
@@ -23,7 +23,10 @@ func main() {
 
 func run(args []string) error {
 	envConfigFile := os.Getenv("CONFIG_FILE")
-	envVerbose, _ := strconv.ParseBool(os.Getenv("VERBOSE"))
+	envVerbose, err := strconv.ParseBool(os.Getenv("VERBOSE"))
+	if err != nil {
+		log.Printf("Warning: failed to parse VERBOSE env var, defaulting to false: %v", err)
+	}
 
 	flags := flag.NewFlagSet(args[0], flag.ExitOnError)
 	configPath := flags.String("file",

--- a/cmd/rt-conf/main.go
+++ b/cmd/rt-conf/main.go
@@ -29,7 +29,7 @@ func run(args []string) error {
 	if ok {
 		verboseDefaultCfg, err = strconv.ParseBool(envVerbose)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to parse VERBOSE env var: %v", err)
 		}
 	}
 

--- a/cmd/rt-conf/main.go
+++ b/cmd/rt-conf/main.go
@@ -26,6 +26,7 @@ func run(args []string) error {
 	envVerbose, err := strconv.ParseBool(os.Getenv("VERBOSE"))
 	if err != nil {
 		log.Printf("Warning: failed to parse VERBOSE env var, defaulting to false: %v", err)
+		envVerbose = false
 	}
 
 	flags := flag.NewFlagSet(args[0], flag.ExitOnError)

--- a/cmd/rt-conf/main.go
+++ b/cmd/rt-conf/main.go
@@ -29,7 +29,7 @@ func run(args []string) error {
 	if ok {
 		verboseDefaultCfg, err = strconv.ParseBool(envVerbose)
 		if err != nil {
-			return fmt.Errorf("failed to parse VERBOSE env var: %v", err)
+			return fmt.Errorf("failed to parse verbose configuration: %v", err)
 		}
 	}
 

--- a/cmd/rt-conf/main_test.go
+++ b/cmd/rt-conf/main_test.go
@@ -66,7 +66,7 @@ func TestRunUnhappy(t *testing.T) {
 			name: "Invalid VERBOSE value",
 			args: []string{"rt-conf", "-file", configPath},
 			envs: []envVar{{key: "VERBOSE", value: "yes"}},
-			err:  "invalid syntax",
+			err:  "failed to parse VERBOSE env var",
 			yaml: `
 kernel-cmdline:
 cpu-governance:

--- a/cmd/rt-conf/main_test.go
+++ b/cmd/rt-conf/main_test.go
@@ -66,7 +66,7 @@ func TestRunUnhappy(t *testing.T) {
 			name: "Invalid VERBOSE value",
 			args: []string{"rt-conf", "-file", configPath},
 			envs: []envVar{{key: "VERBOSE", value: "yes"}},
-			err:  "failed to parse VERBOSE env var",
+			err:  "failed to parse verbose configuration",
 			yaml: `
 kernel-cmdline:
 cpu-governance:

--- a/snap/local/bin/export-env.sh
+++ b/snap/local/bin/export-env.sh
@@ -1,6 +1,10 @@
 #!/bin/bash -e
 
 export CONFIG_FILE=$(snapctl get config-file)
-export VERBOSE=$(snapctl get verbose)
+
+VERBOSE=$(snapctl get verbose)
+if [[ -n $VERBOSE ]]; then
+  export VERBOSE=$VERBOSE
+fi
 
 exec "$@"


### PR DESCRIPTION
## Description

**TIOBE TICS** reports a security impact on this.
```
Rule:	    COV_GO_SUPPRESSED_ERROR_suppressed_error
Level:	    3
Category:	Low impact security
Synopsis:	The error returned by a function is not explicitly checked.
Ruleset:	Go Security
Tool:	    Coverity 2025.6.0
```
